### PR TITLE
fix preferences parsing regxp for passwords with space and/or equals characters

### DIFF
--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -143,6 +143,7 @@ sub put
     return dummylog("PUT", $url, $body) if ($prefs->{dryrun});
     my $req = HTTP::Request->new(PUT => $prefs->{apiurl}.$url);
     $req->header("Content-type" => "text/xml");
+    $req->header("Authorization" => "Basic ".encode_base64($prefs->{username}.":".$prefs->{password}));
     $req->content($body) if defined($body);
     my $resp = repeat($req);
     debuglog($req, $resp) if ($prefs->{"debug"});
@@ -155,6 +156,7 @@ sub post
     my $body = shift;
     return dummylog("POST", $url, $body) if ($prefs->{dryrun});
     my $req = HTTP::Request->new(POST => $prefs->{apiurl}.$url);
+    $req->header("Authorization" => "Basic ".encode_base64($prefs->{username}.":".$prefs->{password}));
     $req->content($body) if defined($body); 
     # some not-proper-API-calls will expect HTTP form POST data;
     # try to determine magically whether we have an XML or form message.
@@ -200,6 +202,7 @@ sub delete
     my $body = shift;
     return dummylog("DELETE", $url, $body) if ($prefs->{dryrun});
     my $req = HTTP::Request->new(DELETE => $prefs->{apiurl}.$url);
+    $req->header("Authorization" => "Basic ".encode_base64($prefs->{username}.":".$prefs->{password}));
     $req->header("Content-type" => "text/xml");
     $req->content($body) if defined($body);
     my $resp = repeat($req);

--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -32,7 +32,7 @@ BEGIN
     open (PREFS, $ENV{HOME}."/.osmtoolsrc") or die "cannot open ". $ENV{HOME}."/.osmtoolsrc";
     while(<PREFS>)
     {
-        if (/^(\S+)\s*=\s*(.*)/)
+        if (/^([^=]*)=(.*)/)
         {
             $prefs->{$1} = $2;
         }


### PR DESCRIPTION
the current code fails if you have a ' ' or '=' char in your password, this change aims to fix that (but means that you can't have whitespace before or after the key/value '=' separator.
