### PR TITLE
Read credentials from command line

### DIFF
--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -39,6 +39,8 @@ BEGIN
     }
     close (PREFS);
     
+    $prefs->{username} = $ENV{OSMTOOLS_USERNAME} if (defined($ENV{OSMTOOLS_USERNAME}));
+    
     if (defined($prefs->{username}))
     {
         print 'User name: ' . $prefs->{username} . "\n";
@@ -50,6 +52,8 @@ BEGIN
         $prefs->{password} = ReadLine(0);
         print "\n";
     }
+    
+    $prefs->{password} = $ENV{OSMTOOLS_PASSWORD} if (defined($ENV{OSMTOOLS_PASSWORD}));
     
     unless (defined($prefs->{password}))
     {

--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -16,6 +16,7 @@ use LWP::UserAgent;
 use MIME::Base64;
 use HTTP::Cookies;
 use URI::Escape;
+use Term::ReadKey;
 
 our $prefs;
 our $ua;
@@ -38,6 +39,26 @@ BEGIN
         }
     }
     close (PREFS);
+    
+    if (defined($prefs->{username}))
+    {
+        print 'User name: ' . $prefs->{username} . "\n";
+    }
+    else
+    {
+        print 'User name: ';
+        $prefs->{password} = ReadLine(0);
+        print "\n";
+    }
+    
+    unless (defined($prefs->{password}))
+    {
+        print 'Password: ';
+        ReadMode('noecho');
+        $prefs->{password} = $1 if (ReadLine(0) =~ /^(.*)\n$/);
+        ReadMode('restore');
+        print "\n";
+    }
 
     foreach my $required("username","password","apiurl")
     {

--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -16,7 +16,6 @@ use LWP::UserAgent;
 use MIME::Base64;
 use HTTP::Cookies;
 use URI::Escape;
-use Term::ReadKey;
 
 our $prefs;
 our $ua;
@@ -46,6 +45,7 @@ BEGIN
     }
     else
     {
+        use Term::ReadKey;
         print 'User name: ';
         $prefs->{password} = ReadLine(0);
         print "\n";
@@ -53,6 +53,7 @@ BEGIN
     
     unless (defined($prefs->{password}))
     {
+        use Term::ReadKey;
         print 'Password: ';
         ReadMode('noecho');
         $prefs->{password} = $1 if (ReadLine(0) =~ /^(.*)\n$/);

--- a/README
+++ b/README
@@ -70,6 +70,11 @@ username=fred
 password=test
 apiurl=http://api06.dev.openstreetmap.org/api/0.6/
 
+If your username or password is not specified in your .osmtoolsrc file, these
+scripts will look for OSMTOOLS_USERNAME and OSMTOOLS_PASSWORD environment
+variables. As a last resort, you will be prompted for a user name or password on
+the command line (requires the Term::ReadKey module).
+
 By default, all tools will run in "dry run" mode, so no changes will 
 be actually written and all write requests will be considered successful.
 Add the "dryrun=0" parameter to the file for live action.


### PR DESCRIPTION
If the user name and/or password is missing from the configuration file, read them from the command line. This change removes the need to specify the password in plain text in a file that’s relatively easy to find.