### PR TITLE
Strip trailing newline from username input prompt

### DIFF
--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -56,7 +56,7 @@ BEGIN
     {
         use Term::ReadKey;
         print 'User name: ';
-        $prefs->{username} = ReadLine(0);
+        $prefs->{username} = $1 if (ReadLine(0) =~ /^(.*)\n$/);
         print "\n";
     }
     


### PR DESCRIPTION
Scripts worked when username was specified in the .osmtoolsrc file but not when prompted for in the terminal.