### PR TITLE
append newline to prefs file if needed before writing instance

### DIFF
--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -29,6 +29,7 @@ BEGIN
 {
 
     $prefs = { "dryrun" => 1 };
+    my $prefs_eol = 1;
 
     open (PREFS, home()."/.osmtoolsrc") or die "cannot open ". home()."/.osmtoolsrc";
     while(<PREFS>)
@@ -37,6 +38,7 @@ BEGIN
         {
             $prefs->{$1} = $2;
         }
+        $prefs_eol = substr ($_, -1) eq "\n";
     }
     close (PREFS);
     
@@ -81,6 +83,7 @@ BEGIN
     {
         $prefs->{instance} = sprintf "%010x", $$ * rand(100000000);
         open(PREFS, ">>".home()."/.osmtoolsrc");
+        printf PREFS "\n" unless $prefs_eol;
         printf PREFS "instance=".$prefs->{instance};
         close(PREFS);
     }


### PR DESCRIPTION
It's possible for `.osmtoolsrc` to be without newline at the end of the last line. For example, when `instance` is appended to this file, no newline is written. On the other hand, it's expected by the scripts that `.osmtoolsrc` ends in newline when `instance` is appended.

This file
```
apiurl=https://api06.dev.openstreetmap.org/api/0.6/
```
will turn into something like this after running the scripts once
```
apiurl=https://api06.dev.openstreetmap.org/api/0.6/instance=0bc73956f7
```
and then into this and the scripts will fail
```
apiurl=https://api06.dev.openstreetmap.org/api/0.6/instance=0bc73956f7instance=1c343fffea
```

This patch adds newline before writing `instance` if there wasn't one. 