### PR TITLE
print request body from dummylog only if it's defined

### DIFF
--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -282,7 +282,7 @@ sub dummylog
 {
     my ($method, $url, $body) = @_;
     print STDERR "$method $url\n";
-    print STDERR "$body\n\n";
+    print STDERR "$body\n\n" if defined($body);
     return $dummy;
 }
 sub set_timeout


### PR DESCRIPTION
Avoid the warning for the PUT request that closes the changeset during a dry run.