### PR TITLE
Batch redaction script

### DIFF
--- a/BatchRedaction.pm
+++ b/BatchRedaction.pm
@@ -52,10 +52,12 @@ sub view
 # Parameters: filename, Redaction ID
 # use empty redaction id to unredact
 # Returns: 1 on success, undef on failure
+# stops on the first failed redaction
 
 sub apply
 {
     my ($filename, $rid) = @_;
+    my $state = 1;
     open(FH, '<', $filename) or return undef;
 
     while(<FH>)
@@ -71,12 +73,13 @@ sub apply
             my $m = $resp->content;
             $m =~ s/\s+/ /g;
             print STDERR "cannot redact $_: ".$resp->status_line.": $m\n";
+            $state = undef;
             last;
         }
     }
 
     close(FH);
-    return 1;
+    return $state;
 }
 
 1;

--- a/BatchRedaction.pm
+++ b/BatchRedaction.pm
@@ -26,6 +26,13 @@ sub view
     $suffix //= "";
     open(FH, '<', $filename) or return undef;
 
+    sub print_content
+    {
+        my ($content) = @_;
+        chomp $content;
+        print "$content\n\n";
+    }
+
     while(<FH>)
     {
         chomp;
@@ -33,16 +40,14 @@ sub view
         my $code = $resp->code;
         if ($resp->is_success) {
             print "# $_ not redacted\n\n";
-            print $resp->content;
-            print "\n";
+            print_content $resp->content;
         } elsif ($code == 404) {
             print "# $_ not found\n\n";
         } elsif ($code == 403) {
             my $resp2 = OsmApi::get($_.$suffix."?show_redactions=true");
             if ($resp2->is_success) {
                 print "# $_ redacted and can be revealed\n\n";
-                print $resp2->content;
-                print "\n";
+                print_content $resp2->content;
             } else {
                 print "# $_ redacted and cannot be revealed\n\n";
             }

--- a/BatchRedaction.pm
+++ b/BatchRedaction.pm
@@ -50,6 +50,7 @@ sub view
 # -----------------------------------------------------------------------------
 # Redacts specific versions of elements listed in a file
 # Parameters: filename, Redaction ID
+# use empty redaction id to unredact
 # Returns: 1 on success, undef on failure
 
 sub apply
@@ -61,7 +62,9 @@ sub apply
     {
         chomp;
         print "redacting $_\n";
-        my $resp = OsmApi::post("$_/redact?redaction=$rid");
+        my $path = "$_/redact";
+        $path .= "?redaction=$rid" if defined $rid;
+        my $resp = OsmApi::post($path);
 
         if (!$resp->is_success)
         {

--- a/BatchRedaction.pm
+++ b/BatchRedaction.pm
@@ -31,7 +31,16 @@ sub view
         chomp;
         print "viewing $_\n";
         my $resp = OsmApi::get($_.$suffix);
-        print $resp->content;
+        if ($resp->is_success) {
+            print $resp->content;
+            next;
+        }
+        print "appears redacted\n";
+        my $resp2 = OsmApi::get($_.$suffix."?show_redactions=true");
+        if ($resp2->is_success) {
+            print "revealed with show_redactions=true\n";
+            print $resp2->content;
+        }
     }
 
     close(FH);

--- a/BatchRedaction.pm
+++ b/BatchRedaction.pm
@@ -29,17 +29,25 @@ sub view
     while(<FH>)
     {
         chomp;
-        print "viewing $_\n";
         my $resp = OsmApi::get($_.$suffix);
+        my $code = $resp->code;
         if ($resp->is_success) {
+            print "# $_ not redacted\n\n";
             print $resp->content;
-            next;
-        }
-        print "appears redacted\n";
-        my $resp2 = OsmApi::get($_.$suffix."?show_redactions=true");
-        if ($resp2->is_success) {
-            print "revealed with show_redactions=true\n";
-            print $resp2->content;
+            print "\n";
+        } elsif ($code == 404) {
+            print "# $_ not found\n\n";
+        } elsif ($code == 403) {
+            my $resp2 = OsmApi::get($_.$suffix."?show_redactions=true");
+            if ($resp2->is_success) {
+                print "# $_ redacted and can be revealed\n\n";
+                print $resp2->content;
+                print "\n";
+            } else {
+                print "# $_ redacted and cannot be revealed\n\n";
+            }
+        } else {
+            print "# $_ encountered unknown error\n\n";
         }
     }
 

--- a/BatchRedaction.pm
+++ b/BatchRedaction.pm
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+
+# BatchRedaction.pm
+# -----------------
+#
+# Implements redaction operations on the OSM API by reading element ids/versions from a file
+#
+# Part of the "osmtools" suite of programs
+# public domain
+
+package BatchRedaction;
+
+use strict;
+use warnings;
+use OsmApi;
+
+# -----------------------------------------------------------------------------
+# Views specific versions of elements listed in a file
+# Parameters: filename, request suffix
+# request suffix is usually empty or ".json"
+# Returns: 1 on success, undef on failure
+
+sub view
+{
+    my ($filename, $suffix) = @_;
+    $suffix //= "";
+    open(FH, '<', $filename) or return undef;
+
+    while(<FH>)
+    {
+        chomp;
+        print "viewing $_\n";
+        my $resp = OsmApi::get($_.$suffix);
+        print $resp->content;
+    }
+
+    close(FH);
+    return 1;
+}
+
+# -----------------------------------------------------------------------------
+# Redacts specific versions of elements listed in a file
+# Parameters: filename, Redaction ID
+# Returns: 1 on success, undef on failure
+
+sub apply
+{
+    my ($filename, $rid) = @_;
+    open(FH, '<', $filename) or return undef;
+
+    while(<FH>)
+    {
+        chomp;
+        print "redacting $_\n";
+        my $resp = OsmApi::post("$_/redact?redaction=$rid");
+
+        if (!$resp->is_success)
+        {
+            my $m = $resp->content;
+            $m =~ s/\s+/ /g;
+            print STDERR "cannot redact $_: ".$resp->status_line.": $m\n";
+            last;
+        }
+    }
+
+    close(FH);
+    return 1;
+}
+
+1;

--- a/batch_redaction.pl
+++ b/batch_redaction.pl
@@ -1,52 +1,28 @@
 #!/usr/bin/perl
 
 use strict;
-#use warnings;
 use FindBin;
 use lib $FindBin::Bin;
-use OsmApi;
+use BatchRedaction;
 
 if (($ARGV[0] eq "view") && (scalar(@ARGV) == 2))
 {
-    open(FH, '<', $ARGV[1]) or die $!;
-
-    while(<FH>)
-    {
-        chomp;
-        print "viewing $_\n";
-        my $resp = OsmApi::get($_);
-        print $resp->content;
-    }
-
-    close(FH);
+    BatchRedaction::view($ARGV[1]);
+}
+elsif (($ARGV[0] eq "view.json") && (scalar(@ARGV) == 2))
+{
+    BatchRedaction::view($ARGV[1], ".json");
 }
 elsif (($ARGV[0] eq "apply") && (scalar(@ARGV) == 3))
 {
-    my $rid = $ARGV[2];
-    open(FH, '<', $ARGV[1]) or die $!;
-
-    while(<FH>)
-    {
-        chomp;
-        print "redacting $_\n";
-        my $resp = OsmApi::post("$_/redact?redaction=$rid");
-
-        if (!$resp->is_success)
-        {
-            my $m = $resp->content;
-            $m =~ s/\s+/ /g;
-            print STDERR "cannot redact $_: ".$resp->status_line.": $m\n";
-            last;
-        }
-    }
-
-    close(FH);
+    BatchRedaction::apply($ARGV[1], $ARGV[2]);
 }
 else
 {
     print <<EOF;
 Usage: 
-  $0 view <filename>          to view osm elements listed in file; each line is <otype>/<oid>/<oversion>
+  $0 view <filename>          to view in xml format osm elements listed in file; each line is <otype>/<oid>/<oversion>
+  $0 view.json <filename>     to view in json format osm elements listed in file; each line is <otype>/<oid>/<oversion>
   $0 apply <filename> <id>    to do redactions from file; each line is <otype>/<oid>/<oversion>
 EOF
     exit;

--- a/batch_redaction.pl
+++ b/batch_redaction.pl
@@ -17,13 +17,22 @@ elsif (($ARGV[0] eq "apply") && (scalar(@ARGV) == 3))
 {
     BatchRedaction::apply($ARGV[1], $ARGV[2]);
 }
+elsif (($ARGV[0] eq "unapply") && (scalar(@ARGV) == 2))
+{
+    BatchRedaction::apply($ARGV[1]);
+}
 else
 {
     print <<EOF;
 Usage: 
-  $0 view <filename>          to view in xml format osm elements listed in file; each line is <otype>/<oid>/<oversion>
-  $0 view.json <filename>     to view in json format osm elements listed in file; each line is <otype>/<oid>/<oversion>
-  $0 apply <filename> <id>    to do redactions from file; each line is <otype>/<oid>/<oversion>
+  $0 view <filename>          to view in xml format osm elements listed in the file
+  $0 view.json <filename>     to view in json format osm elements listed in the file
+  $0 apply <filename> <rid>   to redact elements listed in the file
+  $0 unapply <filename>       to unredact elements listed in the file
+
+where
+  filename : name of file listing element versions; each line is <otype>/<oid>/<oversion>
+  rid : redaction id
 EOF
     exit;
 }

--- a/batch_redaction.pl
+++ b/batch_redaction.pl
@@ -1,14 +1,28 @@
 #!/usr/bin/perl
 
 use strict;
-use warnings;
+#use warnings;
 use FindBin;
 use lib $FindBin::Bin;
 use OsmApi;
 
-if ($ARGV[0] && (scalar(@ARGV) == 2))
+if (($ARGV[0] eq "view") && (scalar(@ARGV) == 2))
 {
-    my $rid = $ARGV[0];
+    open(FH, '<', $ARGV[1]) or die $!;
+
+    while(<FH>)
+    {
+        chomp;
+        print "viewing $_\n";
+        my $resp = OsmApi::get($_);
+        print $resp->content;
+    }
+
+    close(FH);
+}
+elsif (($ARGV[0] eq "apply") && (scalar(@ARGV) == 3))
+{
+    my $rid = $ARGV[2];
     open(FH, '<', $ARGV[1]) or die $!;
 
     while(<FH>)
@@ -32,7 +46,8 @@ else
 {
     print <<EOF;
 Usage: 
-  $0 <id> <filename>     to do redactions from file; each line is <otype>/<oid>/<oversion>
+  $0 view <filename>          to view osm elements listed in file; each line is <otype>/<oid>/<oversion>
+  $0 apply <filename> <id>    to do redactions from file; each line is <otype>/<oid>/<oversion>
 EOF
     exit;
 }

--- a/batch_redaction.pl
+++ b/batch_redaction.pl
@@ -1,0 +1,34 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use FindBin;
+use lib $FindBin::Bin;
+use OsmApi;
+
+if ($ARGV[0] && (scalar(@ARGV) == 1))
+{
+    my $rid = $ARGV[0];
+    while(<STDIN>)
+    {
+        chomp;
+        print "redacting $_\n";
+        my $resp = OsmApi::post("$_/redact?redaction=$rid");
+
+        if (!$resp->is_success)
+        {
+            my $m = $resp->content;
+            $m =~ s/\s+/ /g;
+            print STDERR "cannot redact $_: ".$resp->status_line.": $m\n";
+            last;
+        }
+    }
+}
+else
+{
+    print <<EOF;
+Usage: 
+  $0 <id>                to do redactions from stdin; each line is <otype>/<oid>/<oversion>
+EOF
+    exit;
+}

--- a/batch_redaction.pl
+++ b/batch_redaction.pl
@@ -6,10 +6,12 @@ use FindBin;
 use lib $FindBin::Bin;
 use OsmApi;
 
-if ($ARGV[0] && (scalar(@ARGV) == 1))
+if ($ARGV[0] && (scalar(@ARGV) == 2))
 {
     my $rid = $ARGV[0];
-    while(<STDIN>)
+    open(FH, '<', $ARGV[1]) or die $!;
+
+    while(<FH>)
     {
         chomp;
         print "redacting $_\n";
@@ -23,12 +25,14 @@ if ($ARGV[0] && (scalar(@ARGV) == 1))
             last;
         }
     }
+
+    close(FH);
 }
 else
 {
     print <<EOF;
 Usage: 
-  $0 <id>                to do redactions from stdin; each line is <otype>/<oid>/<oversion>
+  $0 <id> <filename>     to do redactions from file; each line is <otype>/<oid>/<oversion>
 EOF
     exit;
 }


### PR DESCRIPTION
This is a script I'm making redactions with. It takes a list of elements and their versions from a file and makes a redaction api call for each one of them. But there are a couple of issues:

1. The script also exposes undocumented unredact call. I tested it only on dev server.
2. Initially I wanted to read elements/versions from stdin like other scripts do but it causes conflicts with ReadKey login.
