### PR TITLE
postpone reading username/password until it's required

### DIFF
--- a/Note.pm
+++ b/Note.pm
@@ -76,7 +76,7 @@ sub get
 sub create
 {
     my ($lat, $lon, $text) = @_;
-    my $resp = OsmApi::post("notes", "lat=$lat&lon=$lon&text=".uri_escape($text), 1);
+    my $resp = OsmApi::post("notes", "lat=$lat&lon=$lon&text=".uri_escape($text));
     if (!$resp->is_success)
     {
         print STDERR "cannot create note: ".$resp->status_line."\n";

--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -209,10 +209,8 @@ sub post
 {
     my $url = shift;
     my $body = shift;
-    my $force_credentials = shift;
     return dummylog("POST", $url, $body) if ($prefs->{dryrun});
     my $req = HTTP::Request->new(POST => $prefs->{apiurl}.$url);
-    $req->header("Authorization" => "Basic ".encode_base64($prefs->{username}.":".$prefs->{password})) if (defined($force_credentials) && $force_credentials);
     $req->content($body) if defined($body); 
     # some not-proper-API-calls will expect HTTP form POST data;
     # try to determine magically whether we have an XML or form message.

--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -115,6 +115,12 @@ BEGIN
     }
 }
 
+sub add_credentials
+{
+    my $req = shift;
+    $req->header("Authorization" => "Basic ".encode_base64($prefs->{username}.":".$prefs->{password}));
+}
+
 sub login
 {
     $ua->cookie_jar($cookie_jar = HTTP::Cookies->new());
@@ -157,7 +163,6 @@ sub load_web
 sub repeat
 {
     my $req = shift;
-    $req->header("Authorization" => "Basic ".encode_base64($prefs->{username}.":".$prefs->{password}));
     my $resp;
     for (my $i=0; $i<3; $i++)
     {
@@ -172,6 +177,7 @@ sub get
 {
     my $url = shift;
     my $req = HTTP::Request->new(GET => $prefs->{apiurl}.$url);
+    add_credentials($req);
     my $resp = repeat($req);
     debuglog($req, $resp) if ($prefs->{"debug"});
     return($resp);
@@ -181,6 +187,7 @@ sub exists
 {
     my $url = shift;
     my $req = HTTP::Request->new(HEAD => $prefs->{apiurl}.$url);
+    add_credentials($req);
     my $resp = repeat($req);
     debuglog($req, $resp) if ($prefs->{"debug"});
     return($resp->code < 400);
@@ -200,6 +207,7 @@ sub put
     my $req = HTTP::Request->new(PUT => $prefs->{apiurl}.$url);
     $req->header("Content-type" => "text/xml");
     $req->content($body) if defined($body);
+    add_credentials($req);
     my $resp = repeat($req);
     debuglog($req, $resp) if ($prefs->{"debug"});
     return $resp;
@@ -222,6 +230,7 @@ sub post
     {
         $req->header("Content-type" => "text/xml");
     }
+    add_credentials($req);
     my $resp = repeat($req);
     debuglog($req, $resp) if ($prefs->{"debug"});
     return $resp;
@@ -258,6 +267,7 @@ sub delete
     my $req = HTTP::Request->new(DELETE => $prefs->{apiurl}.$url);
     $req->header("Content-type" => "text/xml");
     $req->content($body) if defined($body);
+    add_credentials($req);
     my $resp = repeat($req);
     debuglog($req, $resp) if ($prefs->{"debug"});
     return $resp;

--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -46,35 +46,7 @@ BEGIN
     $prefs->{username} = $ENV{OSMTOOLS_USERNAME} if (defined($ENV{OSMTOOLS_USERNAME}));
     $prefs->{password} = $ENV{OSMTOOLS_PASSWORD} if (defined($ENV{OSMTOOLS_PASSWORD}));
     
-    # read user name from terminal if not set
-    if (defined($prefs->{username}))
-    {
-        # only print user name if we're about to read password interactively
-        unless (defined($prefs->{password}))
-        {
-            print 'User name: ' . $prefs->{username} . "\n"
-        }
-    }
-    else
-    {
-        use Term::ReadKey;
-        print 'User name: ';
-        $prefs->{username} = $1 if (ReadLine(0) =~ /^(.*)\n$/);
-        print "\n";
-    }
-    
-    # read password from terminal if not set
-    unless (defined($prefs->{password}))
-    {
-        use Term::ReadKey;
-        print 'Password: ';
-        ReadMode('noecho');
-        $prefs->{password} = $1 if (ReadLine(0) =~ /^(.*)\n$/);
-        ReadMode('restore');
-        print "\n";
-    }
-
-    foreach my $required("username","password","apiurl")
+    foreach my $required("apiurl")
     {
         die home()."/.osmtoolsrc does not have $required" unless defined($prefs->{$required});
     }
@@ -115,14 +87,52 @@ BEGIN
     }
 }
 
+sub require_username_and_password
+{
+    # read user name from terminal if not set
+    if (defined($prefs->{username}))
+    {
+        # only print user name if we're about to read password interactively
+        unless (defined($prefs->{password}))
+        {
+            print 'User name: ' . $prefs->{username} . "\n"
+        }
+    }
+    else
+    {
+        use Term::ReadKey;
+        print 'User name: ';
+        $prefs->{username} = $1 if (ReadLine(0) =~ /^(.*)\n$/);
+        print "\n";
+    }
+    
+    # read password from terminal if not set
+    unless (defined($prefs->{password}))
+    {
+        use Term::ReadKey;
+        print 'Password: ';
+        ReadMode('noecho');
+        $prefs->{password} = $1 if (ReadLine(0) =~ /^(.*)\n$/);
+        ReadMode('restore');
+        print "\n";
+    }
+
+    foreach my $required("username","password")
+    {
+        die home()."/.osmtoolsrc does not have $required" unless defined($prefs->{$required});
+    }
+}
+
 sub add_credentials
 {
+    require_username_and_password;
     my $req = shift;
     $req->header("Authorization" => "Basic ".encode_base64($prefs->{username}.":".$prefs->{password}));
 }
 
 sub login
 {
+    require_username_and_password;
     $ua->cookie_jar($cookie_jar = HTTP::Cookies->new());
     my $req = HTTP::Request->new(GET => $prefs->{weburl}."login");
     my $resp = $ua->request($req);


### PR DESCRIPTION
- allows running scripts without arguments to see usage info without providing username/password
- this is a step towards oauth logins where username/password won't be required for most actions, although it will still be required for web scraping