### PR TITLE
Option to have two oauth tokens, one for a secondary account

### DIFF
--- a/BatchRedaction.pm
+++ b/BatchRedaction.pm
@@ -44,7 +44,7 @@ sub view
         } elsif ($code == 404) {
             print "# $_ not found\n\n";
         } elsif ($code == 403) {
-            my $resp2 = OsmApi::get($_.$suffix."?show_redactions=true");
+            my $resp2 = OsmApi::get($_.$suffix."?show_redactions=true", undef, 1);
             if ($resp2->is_success) {
                 print "# $_ redacted and can be revealed\n\n";
                 print_content $resp2->content;
@@ -117,7 +117,7 @@ sub apply
         print "redacting $_";
         my $path = "$_/redact";
         $path .= "?redaction=$rid" if $rid;
-        my $resp = OsmApi::post($path);
+        my $resp = OsmApi::post($path, undef, 1);
 
         if ($resp->is_success)
         {

--- a/Note.pm
+++ b/Note.pm
@@ -55,16 +55,10 @@ sub reopen
     return 1;
 }
 
-sub get_raw
-{
-    my ($id) = @_;
-    return OsmApi::get_with_credentials("notes/$id");
-}
-
 sub get
 {
     my ($id) = @_;
-    my $resp = get_raw($id);
+    my $resp = OsmApi::get("notes/$id");
     if (!$resp->is_success)
     {
         print STDERR "cannot load note: ".$resp->status_line."\n";

--- a/Note.pm
+++ b/Note.pm
@@ -26,7 +26,7 @@ sub hide
 {
     my ($id) = @_;
 
-    my $resp = OsmApi::delete("notes/$id");
+    my $resp = OsmApi::delete("notes/$id", undef, 1);
 
     if (!$resp->is_success)
     {
@@ -45,7 +45,7 @@ sub reopen
 {
     my ($id) = @_;
 
-    my $resp = OsmApi::post("notes/$id/reopen");
+    my $resp = OsmApi::post("notes/$id/reopen", undef, 1);
 
     if (!$resp->is_success)
     {
@@ -58,7 +58,7 @@ sub reopen
 sub get
 {
     my ($id) = @_;
-    my $resp = OsmApi::get("notes/$id");
+    my $resp = OsmApi::get("notes/$id", undef, 1);
     if (!$resp->is_success)
     {
         print STDERR "cannot load note: ".$resp->status_line."\n";

--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -102,20 +102,19 @@ INIT
 sub get
 {
     my $url = shift;
+    my $body = shift;
+    my $privileged = shift;
     my $req = HTTP::Request->new(GET => $prefs->{apiurl}.$url);
-    add_credentials($req);
-    my $resp = repeat($req);
-    debuglog($req, $resp) if ($prefs->{"debug"});
-    return($resp);
+    return run_api_request($req, $privileged);
 }
 
 sub exists
 {
     my $url = shift;
+    my $body = shift;
+    my $privileged = shift;
     my $req = HTTP::Request->new(HEAD => $prefs->{apiurl}.$url);
-    add_credentials($req);
-    my $resp = repeat($req);
-    debuglog($req, $resp) if ($prefs->{"debug"});
+    my $resp = run_api_request($req, $privileged);
     return($resp->code < 400);
 }
 
@@ -123,20 +122,19 @@ sub put
 {
     my $url = shift;
     my $body = shift;
+    my $privileged = shift;
     return dummylog("PUT", $url, $body) if ($prefs->{dryrun});
     my $req = HTTP::Request->new(PUT => $prefs->{apiurl}.$url);
     $req->header("Content-type" => "text/xml");
     $req->content($body) if defined($body);
-    add_credentials($req);
-    my $resp = repeat($req);
-    debuglog($req, $resp) if ($prefs->{"debug"});
-    return $resp;
+    return run_api_request($req, $privileged);
 }
 
 sub post
 {
     my $url = shift;
     my $body = shift;
+    my $privileged = shift;
     return dummylog("POST", $url, $body) if ($prefs->{dryrun});
     my $req = HTTP::Request->new(POST => $prefs->{apiurl}.$url);
     $req->content($body) if defined($body); 
@@ -150,24 +148,19 @@ sub post
     {
         $req->header("Content-type" => "text/xml");
     }
-    add_credentials($req);
-    my $resp = repeat($req);
-    debuglog($req, $resp) if ($prefs->{"debug"});
-    return $resp;
+    return run_api_request($req, $privileged);
 }
 
 sub delete
 {
     my $url = shift;
     my $body = shift;
+    my $privileged = shift;
     return dummylog("DELETE", $url, $body) if ($prefs->{dryrun});
     my $req = HTTP::Request->new(DELETE => $prefs->{apiurl}.$url);
     $req->header("Content-type" => "text/xml");
     $req->content($body) if defined($body);
-    add_credentials($req);
-    my $resp = repeat($req);
-    debuglog($req, $resp) if ($prefs->{"debug"});
-    return $resp;
+    return run_api_request($req, $privileged);
 }
 
 # Web subs
@@ -247,6 +240,15 @@ sub append_pref
     printf PREFS "$pref_name=".$prefs->{$pref_name};
     close(PREFS);
     $prefs_eol = 0;
+}
+
+sub run_api_request
+{
+    my $req = shift;
+    add_credentials($req);
+    my $resp = repeat($req);
+    debuglog($req, $resp) if ($prefs->{"debug"});
+    return $resp;
 }
 
 sub require_username_and_password

--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -282,12 +282,6 @@ sub exists
     return($resp->code < 400);
 }
 
-sub get_with_credentials
-{
-    # get is now with credentials by default
-    return get(@_);
-}
-
 sub put
 {
     my $url = shift;

--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -311,15 +311,21 @@ sub require_username_and_password
 sub read_existing_oauth2_token
 {
     my $privileged = shift;
-    if (!$privileged && defined($prefs->{"oauth2_token_unprivileged"}))
+    if (!$privileged && defined($prefs->{"oauth2_token_secondary"}))
     {
-        return $prefs->{"oauth2_token_unprivileged"};
+        return $prefs->{"oauth2_token_secondary"};
     }
     if (defined($prefs->{"oauth2_token"}))
     {
         return $prefs->{"oauth2_token"};
     }
     return undef;
+}
+
+sub check_oauth2_token
+{
+    my $token_name = shift;
+    return defined($prefs->{$token_name});
 }
 
 sub request_oauth2_token

--- a/Redaction.pm
+++ b/Redaction.pm
@@ -111,7 +111,7 @@ sub apply
 
     if (defined($over) && ($over =~ /^\d+$/) && ($over>0) && ($over<=65536))
     {
-        my $resp = OsmApi::post("$otype/$oid/$over/redact?redaction=$rid");
+        my $resp = OsmApi::post("$otype/$oid/$over/redact?redaction=$rid", undef, 1);
 
         if (!$resp->is_success)
         {
@@ -145,7 +145,7 @@ sub apply
 
         foreach(@versions_to_redact)
         {
-            my $resp = OsmApi::post("$otype/$oid/$_/redact?redaction=$rid");
+            my $resp = OsmApi::post("$otype/$oid/$_/redact?redaction=$rid", undef, 1);
 
             if (!$resp->is_success)
             {
@@ -168,7 +168,7 @@ sub apply
         $over = 1;
         while(1)
         {
-            my $resp = OsmApi::post("$otype/$oid/$over/redact?redaction=$rid");
+            my $resp = OsmApi::post("$otype/$oid/$over/redact?redaction=$rid", undef, 1);
 
             if (!$resp->is_success)
             {

--- a/request_tokens.pl
+++ b/request_tokens.pl
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+
+use strict;
+use FindBin;
+use lib $FindBin::Bin;
+use OsmApi;
+
+if (OsmApi::check_oauth2_token("oauth2_token"))
+{
+	print "Primary token is already received. Delete 'oauth2_token' from .osmtoolsrc to request it again.\n";
+}
+else
+{
+	print "\n=== Requesting the primary token. ===\n\nLogin with your osm account that has full permissions.\n";
+	OsmApi::request_oauth2_token("oauth2_token");
+}
+
+if (OsmApi::check_oauth2_token("oauth2_token_secondary"))
+{
+	print "Secondary token is already received. Delete 'oauth2_token_secondary' from .osmtoolsrc to request it again.\n";
+}
+else
+{
+	print "\n=== Requesting the secondary token. ===\n\nLogin with your bot/mechanical edit account.\nAltenatively, if you want to use only one account, interrupt the script.\n";
+	OsmApi::request_oauth2_token("oauth2_token_secondary");
+}


### PR DESCRIPTION
Everything should work like before, unless request_tokens.pl is run. This script requests two tokens: first one should be generated when logged in with a moderator account, second one when logged in with a bot/script/fix account. First token is going to be used only in operations requiring moderator permissions.