### PR TITLE
use Bytes::Random::Secure locally in token request sub

### DIFF
--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -17,7 +17,6 @@ use MIME::Base64 qw(encode_base64 encode_base64url);
 use HTTP::Cookies;
 use URI::Escape;
 use File::HomeDir;
-use Bytes::Random::Secure qw(random_bytes);
 use Digest::SHA qw(sha256);
 
 our $prefs;
@@ -290,7 +289,7 @@ sub require_username_and_password
         $prefs->{username} = $1 if (ReadLine(0) =~ /^(.*)\n$/);
         print "\n";
     }
-    
+
     # read password from terminal if not set
     unless (defined($prefs->{password}))
     {
@@ -330,6 +329,8 @@ sub check_oauth2_token
 
 sub request_oauth2_token
 {
+    use Bytes::Random::Secure qw(random_bytes);
+
     my $token_name = shift;
     my $redirect_uri = "urn:ietf:wg:oauth:2.0:oob";
     my $scope = "read_prefs write_notes write_api";
@@ -343,6 +344,7 @@ sub request_oauth2_token
         "&code_challenge=" . uri_escape($code_challenge) .
         "&code_challenge_method=S256";
     print "Open the following url:\n$request_code_url\n\n";
+
     print "Copy the code here: ";
     my $code;
     while ($code = <STDIN>)


### PR DESCRIPTION
This module is required only for getting a token. If you run scripts remotely and the module is not installed there you can get your tokens on a different machine, then copy them to `.osmtoolsrc` without installing the module.