### PR TITLE
Perl script to download changesets

### DIFF
--- a/UserChangesets.pm
+++ b/UserChangesets.pm
@@ -21,6 +21,7 @@ sub download_metadata
     $to_date = format_date($to_date) if defined($to_date);
     my $updated_to_date = $to_date;
     my %visited_changesets = ();
+    my $download_more = 1;
 
     # existing metadata check phase
 
@@ -34,12 +35,12 @@ sub download_metadata
                 $visited_changesets{$id} = 1;
             }
         });
-        $updated_to_date = update_to_date($updated_to_date, $bottom_created_at) if defined($bottom_created_at);
+        ($updated_to_date, $download_more) = update_to_date($updated_to_date, $bottom_created_at) if defined($bottom_created_at);
     }
 
     # new metadata download phase
 
-    while (1)
+    while ($download_more)
     {
         my $time_arg = "";
         if (defined($updated_to_date))
@@ -82,7 +83,7 @@ sub download_metadata
 
         last if $new_changesets_count == 0;
 
-        $updated_to_date = update_to_date($updated_to_date, $bottom_created_at);
+        ($updated_to_date) = update_to_date($updated_to_date, $bottom_created_at);
     }
 }
 
@@ -136,15 +137,14 @@ sub update_to_date
 {
     my ($to_date, $bottom_created_at) = @_;
     my $new_timestamp = str2time($bottom_created_at) + 1;
+    my $updated = !defined($to_date) || $new_timestamp < str2time($to_date);
 
-    if (!defined($to_date) || $new_timestamp < str2time($to_date))
+    if ($updated)
     {
-        return format_date(time2isoz($new_timestamp));
+        $to_date = format_date(time2isoz($new_timestamp));
     }
-    else
-    {
-        return $to_date;
-    }
+
+    return ($to_date, $updated);
 }
 
 sub format_date

--- a/UserChangesets.pm
+++ b/UserChangesets.pm
@@ -1,0 +1,156 @@
+#!/usr/bin/perl
+
+package UserChangesets;
+
+use strict;
+use warnings;
+use URI::Escape;
+use HTTP::Date qw(str2time time2isoz);
+use OsmApi;
+use Changeset;
+
+# -----------------------------------------------------------------------------
+# Downloads given user's changesets
+# Parameters: output directory name, user argument, from date, to date
+# user argument is either display_name=... or user=... with urlencoded display name or id
+
+sub download
+{
+    my ($output_dirname, $user_arg, $since_date, $to_date) = @_;
+    $since_date = format_date($since_date);
+    $to_date = format_date($to_date) if defined($to_date);
+
+    # existing metadata check phase
+
+    my $updated_to_date = $to_date;
+    my %visited_changesets = ();
+    my $meta_output_dirname = "$output_dirname/meta";
+    mkdir $meta_output_dirname unless -d $meta_output_dirname;
+
+    foreach my $list_filename (reverse glob("$meta_output_dirname/*.osm"))
+    {
+        my $bottom_created_at;
+        iterate_over_changesets($list_filename, sub {
+            my ($id, $created_at, $closed_at) = @_;
+            $bottom_created_at = $created_at;
+            if (!$visited_changesets{$id}) {
+                $visited_changesets{$id} = 1;
+            }
+        });
+        $updated_to_date = update_to_date($updated_to_date, $bottom_created_at) if defined($bottom_created_at);
+    }
+
+    # new metadata download phase
+
+    while (1)
+    {
+        my $time_arg = "";
+        if (defined($updated_to_date))
+        {
+            $time_arg = "time=" . uri_escape($since_date) . "," . uri_escape($updated_to_date);
+        }
+        else
+        {
+            $time_arg = "time=" . uri_escape($since_date);
+        }
+
+        my $resp = OsmApi::get("changesets?$user_arg&$time_arg");
+        if (!$resp->is_success)
+        {
+            die "changeset metadata fetch failed: " . $resp->status_line;
+        }
+
+        my $list = $resp->content;
+        my ($top_created_at, $bottom_created_at);
+        my $new_changesets_count = 0;
+
+        iterate_over_changesets(\$list, sub {
+            my ($id, $created_at, $closed_at) = @_;
+            $bottom_created_at = $created_at;
+            $top_created_at = $created_at unless defined($top_created_at);
+            if (!$visited_changesets{$id}) {
+                $new_changesets_count++;
+                $visited_changesets{$id} = 1;
+            }
+        });
+
+        if (defined($top_created_at))
+        {
+            $_ = $top_created_at;
+            my $list_filename = "$meta_output_dirname/$_.osm";
+            open(my $list_fh, '>', $list_filename) or die "can't open changeset list file '$list_filename' for writing";
+            print $list_fh $list;
+            close $list_fh;
+        }
+
+        last if $new_changesets_count == 0;
+
+        $updated_to_date = update_to_date($updated_to_date, $bottom_created_at);
+    }
+
+    # changes download phase
+
+    my $changes_output_dirname = "$output_dirname/changes";
+    mkdir $changes_output_dirname unless -d $changes_output_dirname;
+    foreach my $list_filename (reverse glob("$meta_output_dirname/*.osm"))
+    {
+        my $since_timestamp = str2time($since_date);
+        my $to_timestamp = str2time($to_date);
+        iterate_over_changesets($list_filename, sub {
+            my ($id, $created_at, $closed_at) = @_;
+            my $changes_filename = "$changes_output_dirname/$id.osc";
+            return if -f $changes_filename;
+            return if (str2time($closed_at) < $since_timestamp);
+            return if (defined($to_timestamp) && str2time($created_at) >= $to_timestamp);
+            my $osc = Changeset::download($id) or die "failed to download changeset $id";
+            open(my $fh, '>', $changes_filename) or die "can't open changes file '$changes_filename' for writing";
+            print $fh $osc;
+            close $fh;
+        });
+    }
+}
+
+sub iterate_over_changesets
+{
+    my ($list_source, $handler) = @_;
+
+    open my $list_fh, '<', $list_source;
+    while (<$list_fh>)
+    {
+        next unless /<changeset/;
+        /id="(\d+)"/;
+        my $id = $1;
+        /created_at="([^"]*)"/;
+        my $created_at = $1;
+        /closed_at="([^"]*)"/;
+        my $closed_at = $1;
+        next unless defined($id) && defined($created_at) && defined($closed_at);
+        $handler -> ($id, format_date($created_at), format_date($closed_at));
+    }
+    close $list_fh;
+}
+
+sub update_to_date
+{
+    my ($to_date, $bottom_created_at) = @_;
+    my $new_timestamp = str2time($bottom_created_at) + 1;
+
+    if (!defined($to_date) || $new_timestamp < str2time($to_date))
+    {
+        return format_date(time2isoz($new_timestamp));
+    }
+    else
+    {
+        return $to_date;
+    }
+}
+
+sub format_date
+{
+    my $date = shift;
+    $date =~ s/ /T/;
+    $date =~ tr/-://d;
+    return $date;
+}
+
+1;

--- a/download_changesets.pl
+++ b/download_changesets.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use FindBin;
+use lib $FindBin::Bin;
+use Getopt::Long;
+
+my $username;
+my $uid;
+my $since_date = "2001-01-01T00:00:00Z";
+my $to_date;
+my $output_dir;
+
+GetOptions(
+    "u:s" => \$username,
+    "uid:i" => \$uid,
+    "s:s" => \$since_date,
+    "t:s" => \$to_date,
+    "o:s" => \$output_dir
+);
+
+print "TODO ($username)($uid)($since_date)($to_date)($output_dir)\n";

--- a/download_changesets.pl
+++ b/download_changesets.pl
@@ -51,10 +51,9 @@ else
 
 mkdir $output_dirname unless -d $output_dirname;
 
-my %visited_changesets = ();
-
 # metadata download phase
 
+my %visited_changesets = ();
 my $meta_output_dirname = "$output_dirname/meta";
 mkdir $meta_output_dirname unless -d $meta_output_dirname;
 
@@ -104,6 +103,13 @@ while (1)
 
     $to_date = time2isoz(str2time($bottom_created_at) + 1);
     $to_date =~ s/ /T/;
+}
+
+# changes download phase
+
+foreach my $list_filename (reverse glob("$meta_output_dirname/*.osm"))
+{
+    print "read file $list_filename\n";
 }
 
 sub iterate_over_changesets

--- a/download_changesets.pl
+++ b/download_changesets.pl
@@ -12,14 +12,14 @@ my $username;
 my $uid;
 my $since_date = "2001-01-01T00:00:00Z";
 my $to_date;
-my $output_dir;
+my $output_dirname;
 
 GetOptions(
     "username|u=s" => \$username,
     "id|uid=i" => \$uid,
     "from|since=s" => \$since_date,
     "to=s" => \$to_date,
-    "output=s" => \$output_dir
+    "output=s" => \$output_dirname
 ) or die("Error in command line arguments\n");
 
 my $user_arg;
@@ -32,7 +32,7 @@ if (defined($username))
     else
     {
         $user_arg = "display_name=" . uri_escape($username);
-        $output_dir = "changesets_$user_arg" unless defined($output_dir);
+        $output_dirname = "changesets_$username" unless defined($output_dirname);
     }
 }
 else
@@ -40,7 +40,7 @@ else
     if (defined($uid))
     {
         $user_arg = "user=" . uri_escape($uid);
-        $output_dir = "changesets_$uid" unless defined($output_dir);
+        $output_dirname = "changesets_$uid" unless defined($output_dirname);
     }
     else
     {
@@ -48,19 +48,32 @@ else
     }
 }
 
-my $time_arg = "";
-if (defined($to_date))
-{
-    $time_arg = "time=" . uri_escape($since_date) . "," . uri_escape($to_date);
-}
-else
-{
-    $time_arg = "time=" . uri_escape($since_date);
-}
+mkdir $output_dirname unless -d $output_dirname;
 
-my $resp = OsmApi::get("changesets?$user_arg&$time_arg");
-if (!$resp->is_success) {
-    die "changeset metadata fetch failed: " . $resp->status_line;
-}
+while (1)
+{
+    my $time_arg = "";
+    if (defined($to_date))
+    {
+        $time_arg = "time=" . uri_escape($since_date) . "," . uri_escape($to_date);
+    }
+    else
+    {
+        $time_arg = "time=" . uri_escape($since_date);
+    }
 
-print $resp->content;
+    my $resp = OsmApi::get("changesets?$user_arg&$time_arg");
+    if (!$resp->is_success) {
+        die "changeset metadata fetch failed: " . $resp->status_line;
+    }
+
+    $_ = $since_date;
+    tr/-://d;
+    my $list_filename = "$output_dirname/$_.xml";
+    my $list_fh;
+    open($list_fh, '>', $list_filename) or die "can't open changeset list file '$list_filename' for writing";
+    print $list_fh $resp->content;
+    close $list_fh;
+
+    last;
+}

--- a/download_changesets.pl
+++ b/download_changesets.pl
@@ -16,6 +16,21 @@ my $since_date = "2001-01-01T00:00:00Z";
 my $to_date;
 my $output_dirname;
 
+if (scalar(@ARGV) == 0)
+{
+    print <<EOF;
+options:
+  --username <username>
+  --uid <uid>
+  --from <date>
+  --to <date>
+  --output <directory>
+
+  either username or uid has to be supplied for the script to run
+EOF
+    exit;
+}
+
 GetOptions(
     "username|u=s" => \$username,
     "id|uid=i" => \$uid,

--- a/download_changesets.pl
+++ b/download_changesets.pl
@@ -54,6 +54,10 @@ mkdir $output_dirname unless -d $output_dirname;
 my %visited_changesets = ();
 
 # metadata download phase
+
+my $meta_output_dirname = "$output_dirname/meta";
+mkdir $meta_output_dirname unless -d $meta_output_dirname;
+
 while (1)
 {
     my $time_arg = "";
@@ -78,7 +82,6 @@ while (1)
 
     iterate_over_changesets(\$list, sub {
         my ($id, $created_at, $closed_at) = @_;
-        print "$id $created_at $closed_at\n";
         $bottom_created_at = $created_at;
         $top_created_at = $created_at unless defined($top_created_at);
         if (!$visited_changesets{$id}) {
@@ -91,7 +94,7 @@ while (1)
     {
         $_ = $top_created_at;
         tr/-://d;
-        my $list_filename = "$output_dirname/list_$_.xml";
+        my $list_filename = "$meta_output_dirname/$_.osm";
         open(my $list_fh, '>', $list_filename) or die "can't open changeset list file '$list_filename' for writing";
         print $list_fh $list;
         close $list_fh;

--- a/user_changesets.pl
+++ b/user_changesets.pl
@@ -6,9 +6,7 @@ use FindBin;
 use lib $FindBin::Bin;
 use Getopt::Long;
 use URI::Escape;
-use HTTP::Date qw(str2time time2isoz);
-use OsmApi;
-use Changeset;
+use UserChangesets;
 
 my $username;
 my $uid;
@@ -42,9 +40,6 @@ GetOptions(
     "output=s" => \$output_dirname
 ) or die("Error in command line arguments\n");
 
-$since_date = format_date($since_date);
-$to_date = format_date($to_date) if defined($to_date);
-
 my $user_arg;
 if (defined($username))
 {
@@ -73,136 +68,4 @@ else
 
 mkdir $output_dirname unless -d $output_dirname;
 
-# existing metadata check phase
-
-my $updated_to_date = $to_date;
-my %visited_changesets = ();
-my $meta_output_dirname = "$output_dirname/meta";
-mkdir $meta_output_dirname unless -d $meta_output_dirname;
-
-foreach my $list_filename (reverse glob("$meta_output_dirname/*.osm"))
-{
-    my $bottom_created_at;
-    iterate_over_changesets($list_filename, sub {
-        my ($id, $created_at, $closed_at) = @_;
-        $bottom_created_at = $created_at;
-        if (!$visited_changesets{$id}) {
-            $visited_changesets{$id} = 1;
-        }
-    });
-    $updated_to_date = update_to_date($updated_to_date, $bottom_created_at) if defined($bottom_created_at);
-}
-
-# new metadata download phase
-
-while (1)
-{
-    my $time_arg = "";
-    if (defined($updated_to_date))
-    {
-        $time_arg = "time=" . uri_escape($since_date) . "," . uri_escape($updated_to_date);
-    }
-    else
-    {
-        $time_arg = "time=" . uri_escape($since_date);
-    }
-
-    my $resp = OsmApi::get("changesets?$user_arg&$time_arg");
-    if (!$resp->is_success)
-    {
-        die "changeset metadata fetch failed: " . $resp->status_line;
-    }
-
-    my $list = $resp->content;
-    my ($top_created_at, $bottom_created_at);
-    my $new_changesets_count = 0;
-
-    iterate_over_changesets(\$list, sub {
-        my ($id, $created_at, $closed_at) = @_;
-        $bottom_created_at = $created_at;
-        $top_created_at = $created_at unless defined($top_created_at);
-        if (!$visited_changesets{$id}) {
-            $new_changesets_count++;
-            $visited_changesets{$id} = 1;
-        }
-    });
-
-    if (defined($top_created_at))
-    {
-        $_ = $top_created_at;
-        my $list_filename = "$meta_output_dirname/$_.osm";
-        open(my $list_fh, '>', $list_filename) or die "can't open changeset list file '$list_filename' for writing";
-        print $list_fh $list;
-        close $list_fh;
-    }
-
-    last if $new_changesets_count == 0;
-
-    $updated_to_date = update_to_date($updated_to_date, $bottom_created_at);
-}
-
-# changes download phase
-
-my $changes_output_dirname = "$output_dirname/changes";
-mkdir $changes_output_dirname unless -d $changes_output_dirname;
-foreach my $list_filename (reverse glob("$meta_output_dirname/*.osm"))
-{
-    my $since_timestamp = str2time($since_date);
-    my $to_timestamp = str2time($to_date);
-    iterate_over_changesets($list_filename, sub {
-        my ($id, $created_at, $closed_at) = @_;
-        my $changes_filename = "$changes_output_dirname/$id.osc";
-        return if -f $changes_filename;
-        return if (str2time($closed_at) < $since_timestamp);
-        return if (defined($to_timestamp) && str2time($created_at) >= $to_timestamp);
-        my $osc = Changeset::download($id) or die "failed to download changeset $id";
-        open(my $fh, '>', $changes_filename) or die "can't open changes file '$changes_filename' for writing";
-        print $fh $osc;
-        close $fh;
-    });
-}
-
-#
-
-sub iterate_over_changesets
-{
-    my ($list_source, $handler) = @_;
-
-    open my $list_fh, '<', $list_source;
-    while (<$list_fh>)
-    {
-        next unless /<changeset/;
-        /id="(\d+)"/;
-        my $id = $1;
-        /created_at="([^"]*)"/;
-        my $created_at = $1;
-        /closed_at="([^"]*)"/;
-        my $closed_at = $1;
-        next unless defined($id) && defined($created_at) && defined($closed_at);
-        $handler -> ($id, format_date($created_at), format_date($closed_at));
-    }
-    close $list_fh;
-}
-
-sub update_to_date
-{
-    my ($to_date, $bottom_created_at) = @_;
-    my $new_timestamp = str2time($bottom_created_at) + 1;
-
-    if (!defined($to_date) || $new_timestamp < str2time($to_date))
-    {
-        return format_date(time2isoz($new_timestamp));
-    }
-    else
-    {
-        return $to_date;
-    }
-}
-
-sub format_date
-{
-    my $date = shift;
-    $date =~ s/ /T/;
-    $date =~ tr/-://d;
-    return $date;
-}
+UserChangesets::download($output_dirname, $user_arg, $since_date, $to_date);

--- a/user_changesets.pl
+++ b/user_changesets.pl
@@ -14,11 +14,12 @@ my $since_date = "2001-01-01T00:00:00Z";
 my $to_date;
 my $output_dirname;
 
-if ((scalar(@ARGV) == 0) || ($ARGV[0] ne "download"))
+if ((scalar(@ARGV) < 2) || ($ARGV[0] ne "download") || (($ARGV[1] ne "metadata") && ($ARGV[1] ne "changes")))
 {
     print <<EOF;
 Usage:
-  $0 download <options>
+  $0 download metadata <options>
+  $0 download changes <options>
 
 options:
   --username <username>
@@ -68,4 +69,13 @@ else
 
 mkdir $output_dirname unless -d $output_dirname;
 
-UserChangesets::download($output_dirname, $user_arg, $since_date, $to_date);
+my $metadata_output_dirname = "$output_dirname/metadata";
+mkdir $metadata_output_dirname unless -d $metadata_output_dirname;
+UserChangesets::download_metadata($metadata_output_dirname, $user_arg, $since_date, $to_date);
+
+if ($ARGV[1] eq "changes")
+{
+    my $changes_output_dirname = "$output_dirname/changes";
+    mkdir $changes_output_dirname unless -d $changes_output_dirname;
+    UserChangesets::download_changes($metadata_output_dirname, $changes_output_dirname, $since_date, $to_date);
+}

--- a/user_changesets.pl
+++ b/user_changesets.pl
@@ -16,9 +16,12 @@ my $since_date = "2001-01-01T00:00:00Z";
 my $to_date;
 my $output_dirname;
 
-if (scalar(@ARGV) == 0)
+if ((scalar(@ARGV) == 0) || ($ARGV[0] ne "download"))
 {
     print <<EOF;
+Usage:
+  $0 download <options>
+
 options:
   --username <username>
   --uid <uid>


### PR DESCRIPTION
Uses `.osmtoolsrc` config.
Can later be modified to download redacted changes.