### PR TITLE
warn when user input is required while stdin is busy

### DIFF
--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -330,6 +330,7 @@ sub check_oauth2_token
 
 sub request_oauth2_token
 {
+    die "oauth2 token request requires typing/pasting a code, but STDIN is busy with piped input\ntry running request_tokens.pl first to get oauth2 tokens" unless -t STDIN;
     my $token_name = shift;
     my $redirect_uri = "urn:ietf:wg:oauth:2.0:oob";
     my $scope = "read_prefs write_notes write_api";


### PR DESCRIPTION
Some scripts read input from stdin. If no tokens are saved in .osmtoolsrc, they also need to get codes that are exchanged for tokens. The codes have to be copied by the user from osm authorization page. The easiest way to get them is also to read them from stdin. But this is not going to work together with another stdin input piped from somewhere.

Here I try to detect if stdin is busy before asking for user input.