### PR TITLE
Write error message when requesting token for unknown client id

### DIFF
--- a/OsmApi.pm
+++ b/OsmApi.pm
@@ -330,9 +330,11 @@ sub check_oauth2_token
 sub request_oauth2_token
 {
     die "oauth2 token request requires typing/pasting a code, but STDIN is busy with piped input\ntry running request_tokens.pl first to get oauth2 tokens" unless -t STDIN;
+    die "Requesting oauth2 tokens requires 'oauth2_client_id' to be set in .osmtoolsrc for custom 'apiurl'." unless (defined($prefs->{oauth2_client_id}) && $prefs->{oauth2_client_id});
+
     use Bytes::Random::Secure qw(random_bytes);
 
-my $token_name = shift;
+    my $token_name = shift;
     my $redirect_uri = "urn:ietf:wg:oauth:2.0:oob";
     my $scope = "read_prefs write_notes write_api";
     my $code_verifier = encode_base64url random_bytes(48);


### PR DESCRIPTION
otherwise a url with missing client id is given to the user, that's obviously not going to work

missing client id is going to happen for custom unrecognized api urls, or if it's deliberately deleted in config