### PR TITLE
Fix some issues with dates in user_changesets.pl

### DIFF
--- a/UserChangesets.pm
+++ b/UserChangesets.pm
@@ -54,10 +54,12 @@ sub download_metadata
         if (defined($updated_to_timestamp))
         {
             $time_arg = "time=" . make_http_date_from_timestamp($from_timestamp) . "," . make_http_date_from_timestamp($updated_to_timestamp);
+            print "requesting changeset metadata down from " . time2isoz($updated_to_timestamp) . "\n";
         }
         else
         {
             $time_arg = "time=" . make_http_date_from_timestamp($from_timestamp);
+            print "requesting changeset metadata down from current moment\n";
         }
 
         my $resp = OsmApi::get("changesets?$user_arg&$time_arg");

--- a/UserChangesets.pm
+++ b/UserChangesets.pm
@@ -10,16 +10,24 @@ use OsmApi;
 use Changeset;
 
 # -----------------------------------------------------------------------------
+# Converts date string from script arguments to timestamp
+# Returns undefined if date format is not recognized
+
+sub parse_date
+{
+    my ($date) = @_;
+    return str2time($date, "GMT");
+}
+
+# -----------------------------------------------------------------------------
 # Downloads given user's changeset metadata (open/close dates, bboxes, tags, ...)
-# Parameters: metadata directory for output, user argument, from date, to date
+# Parameters: metadata directory for output, user argument, from timestamp, to timestamp
 # user argument is either display_name=... or user=... with urlencoded display name or id
 
 sub download_metadata
 {
-    my ($metadata_dirname, $user_arg, $since_date, $to_date) = @_;
-    $since_date = format_date($since_date);
-    $to_date = format_date($to_date) if defined($to_date);
-    my $updated_to_date = $to_date;
+    my ($metadata_dirname, $user_arg, $from_timestamp, $to_timestamp) = @_;
+    my $updated_to_timestamp = $to_timestamp;
     my %visited_changesets = ();
     my $download_more = 1;
 
@@ -35,7 +43,7 @@ sub download_metadata
                 $visited_changesets{$id} = 1;
             }
         });
-        ($updated_to_date, $download_more) = update_to_date($updated_to_date, $bottom_created_at) if defined($bottom_created_at);
+        ($updated_to_timestamp, $download_more) = update_to_timestamp($updated_to_timestamp, $bottom_created_at) if defined($bottom_created_at);
     }
 
     # new metadata download phase
@@ -43,13 +51,13 @@ sub download_metadata
     while ($download_more)
     {
         my $time_arg = "";
-        if (defined($updated_to_date))
+        if (defined($updated_to_timestamp))
         {
-            $time_arg = "time=" . uri_escape($since_date) . "," . uri_escape($updated_to_date);
+            $time_arg = "time=" . make_http_date($from_timestamp) . "," . make_http_date($updated_to_timestamp);
         }
         else
         {
-            $time_arg = "time=" . uri_escape($since_date);
+            $time_arg = "time=" . make_http_date($from_timestamp);
         }
 
         my $resp = OsmApi::get("changesets?$user_arg&$time_arg");
@@ -74,8 +82,7 @@ sub download_metadata
 
         if (defined($top_created_at))
         {
-            $_ = $top_created_at;
-            my $list_filename = "$metadata_dirname/$_.osm";
+            my $list_filename = "$metadata_dirname/" . make_compact_date($top_created_at) . ".osm";
             open(my $list_fh, '>', $list_filename) or die "can't open changeset list file '$list_filename' for writing";
             print $list_fh $list;
             close $list_fh;
@@ -83,17 +90,17 @@ sub download_metadata
 
         last if $new_changesets_count == 0;
 
-        ($updated_to_date) = update_to_date($updated_to_date, $bottom_created_at);
+        ($updated_to_timestamp) = update_to_timestamp($updated_to_timestamp, $bottom_created_at);
     }
 }
 
 # -----------------------------------------------------------------------------
 # Downloads changeset changes (elements) matching provided metadata and date rande
-# Parameters: metadata directory to be scanned, changes directory for output, from date, to date
+# Parameters: metadata directory to be scanned, changes directory for output, from timestamp, to timestamp
 
 sub download_changes
 {
-    my ($metadata_dirname, $changes_dirname, $since_date, $to_date) = @_;
+    my ($metadata_dirname, $changes_dirname, $from_timestamp, $to_timestamp) = @_;
     my %changesets_in_range = ();
     my %changesets_downloaded = ();
     my %changesets_to_download = ();
@@ -101,11 +108,9 @@ sub download_changes
 
     foreach my $list_filename (reverse glob("$metadata_dirname/*.osm"))
     {
-        my $since_timestamp = str2time($since_date);
-        my $to_timestamp = str2time($to_date);
         iterate_over_changesets($list_filename, sub {
             my ($id, $created_at, $closed_at) = @_;
-            return if (str2time($closed_at) < $since_timestamp);
+            return if (str2time($closed_at) < $from_timestamp);
             return if (defined($to_timestamp) && str2time($created_at) >= $to_timestamp);
             $changesets_in_range{$id} = 1;
             my $changes_filename = "$changes_dirname/$id.osc";
@@ -145,22 +150,20 @@ sub download_changes
 
 # -----------------------------------------------------------------------------
 # Count downloaded changesets inside given date range
-# Parameters: metadata directory, changes directory, from date, to date
+# Parameters: metadata directory, changes directory, from timestamp, to timestamp
 
 sub count
 {
-    my ($metadata_dirname, $changes_dirname, $since_date, $to_date) = @_;
+    my ($metadata_dirname, $changes_dirname, $from_timestamp, $to_timestamp) = @_;
     my %visited_changesets = ();
     my $metadata_count = 0;
     my $changes_count = 0;
 
     foreach my $list_filename (reverse glob("$metadata_dirname/*.osm"))
     {
-        my $since_timestamp = str2time($since_date);
-        my $to_timestamp = str2time($to_date);
         iterate_over_changesets($list_filename, sub {
             my ($id, $created_at, $closed_at) = @_;
-            return if (str2time($closed_at) < $since_timestamp);
+            return if (str2time($closed_at) < $from_timestamp);
             return if (defined($to_timestamp) && str2time($created_at) >= $to_timestamp);
             return if $visited_changesets{$id};
             $visited_changesets{$id} = 1;
@@ -189,26 +192,33 @@ sub iterate_over_changesets
         /closed_at="([^"]*)"/;
         my $closed_at = $1;
         next unless defined($id) && defined($created_at) && defined($closed_at);
-        $handler -> ($id, format_date($created_at), format_date($closed_at));
+        $handler -> ($id, $created_at, $closed_at);
     }
     close $list_fh;
 }
 
-sub update_to_date
+sub update_to_timestamp
 {
-    my ($to_date, $bottom_created_at) = @_;
+    my ($to_timestamp, $bottom_created_at) = @_;
     my $new_timestamp = str2time($bottom_created_at) + 1;
-    my $updated = !defined($to_date) || $new_timestamp < str2time($to_date);
+    my $updated = !defined($to_timestamp) || $new_timestamp < $to_timestamp;
 
     if ($updated)
     {
-        $to_date = format_date(time2isoz($new_timestamp));
+        $to_timestamp = $new_timestamp;
     }
 
-    return ($to_date, $updated);
+    return ($to_timestamp, $updated);
 }
 
-sub format_date
+sub make_http_date
+{
+    my $timestamp = shift;
+    my $date = time2isoz($timestamp);
+    return uri_escape(make_compact_date($date));
+}
+
+sub make_compact_date
 {
     my $date = shift;
     $date =~ s/ /T/;

--- a/UserChangesets.pm
+++ b/UserChangesets.pm
@@ -53,11 +53,11 @@ sub download_metadata
         my $time_arg = "";
         if (defined($updated_to_timestamp))
         {
-            $time_arg = "time=" . make_http_date($from_timestamp) . "," . make_http_date($updated_to_timestamp);
+            $time_arg = "time=" . make_http_date_from_timestamp($from_timestamp) . "," . make_http_date_from_timestamp($updated_to_timestamp);
         }
         else
         {
-            $time_arg = "time=" . make_http_date($from_timestamp);
+            $time_arg = "time=" . make_http_date_from_timestamp($from_timestamp);
         }
 
         my $resp = OsmApi::get("changesets?$user_arg&$time_arg");
@@ -82,7 +82,7 @@ sub download_metadata
 
         if (defined($top_created_at))
         {
-            my $list_filename = "$metadata_dirname/" . make_compact_date($top_created_at) . ".osm";
+            my $list_filename = "$metadata_dirname/" . make_filename_from_date_attr_value($top_created_at);
             open(my $list_fh, '>', $list_filename) or die "can't open changeset list file '$list_filename' for writing";
             print $list_fh $list;
             close $list_fh;
@@ -211,11 +211,19 @@ sub update_to_timestamp
     return ($to_timestamp, $updated);
 }
 
-sub make_http_date
+sub make_http_date_from_timestamp
 {
     my $timestamp = shift;
     my $date = time2isoz($timestamp);
     return uri_escape(make_compact_date($date));
+}
+
+sub make_filename_from_date_attr_value
+{
+    my $date_attr_value = shift;
+    my $timestamp = str2time($date_attr_value);
+    die "invalid date format in xml date attribute ($date_attr_value)" unless defined($timestamp);
+    return make_compact_date(time2isoz($timestamp)) . ".osm";
 }
 
 sub make_compact_date

--- a/UserChangesets.pm
+++ b/UserChangesets.pm
@@ -16,6 +16,9 @@ use Changeset;
 sub parse_date
 {
     my ($date) = @_;
+    return undef unless defined($date);
+    $date = "$1-$2-01" if $date =~ /^(\d\d\d\d)-(\d\d)$/;
+    $date = "$1-01-01" if $date =~ /^(\d\d\d\d)$/;
     return str2time($date, "GMT");
 }
 

--- a/user_changesets.pl
+++ b/user_changesets.pl
@@ -9,17 +9,22 @@ use UserChangesets;
 
 my $username;
 my $uid;
-my $since_date = "2001-01-01T00:00:00Z";
+my $from_date = "2001-01-01";
 my $to_date;
 my $dirname;
 
 my $correct_options = GetOptions(
     "username|u=s" => \$username,
     "id|uid=i" => \$uid,
-    "from|since=s" => \$since_date,
+    "from|since=s" => \$from_date,
     "to=s" => \$to_date,
     "directory|output=s" => \$dirname
 );
+
+my $from_timestamp = UserChangesets::parse_date($from_date);
+die "unrecognized 'from' date format" unless defined($from_timestamp);
+my $to_timestamp = UserChangesets::parse_date($to_date);
+die "unrecognized 'to' date format" if defined($to_date) && !defined($to_timestamp);
 
 if ($correct_options && ($ARGV[0] eq "download") && ($ARGV[1] eq "metadata") || ($ARGV[1] eq "changes"))
 {
@@ -31,13 +36,13 @@ if ($correct_options && ($ARGV[0] eq "download") && ($ARGV[1] eq "metadata") || 
 
     my $metadata_dirname = "$dirname/metadata";
     mkdir $metadata_dirname unless -d $metadata_dirname;
-    UserChangesets::download_metadata($metadata_dirname, $user_arg, $since_date, $to_date);
+    UserChangesets::download_metadata($metadata_dirname, $user_arg, $from_timestamp, $to_timestamp);
 
     if ($ARGV[1] eq "changes")
     {
         my $changes_dirname = "$dirname/changes";
         mkdir $changes_dirname unless -d $changes_dirname;
-        UserChangesets::download_changes($metadata_dirname, $changes_dirname, $since_date, $to_date);
+        UserChangesets::download_changes($metadata_dirname, $changes_dirname, $from_timestamp, $to_timestamp);
     }
 }
 elsif ($correct_options && ($ARGV[0] eq "count"))
@@ -50,7 +55,7 @@ elsif ($correct_options && ($ARGV[0] eq "count"))
 
     my $metadata_dirname = "$dirname/metadata";
     my $changes_dirname = "$dirname/changes";
-    UserChangesets::count($metadata_dirname, $changes_dirname, $since_date, $to_date);
+    UserChangesets::count($metadata_dirname, $changes_dirname, $from_timestamp, $to_timestamp);
 }
 else
 {


### PR DESCRIPTION
- error messages on invalid dates
- treat all dates as UTC
- print top date in query range while downloading metadata
- allow dates consisting only of year or year-month