### PR TITLE
Commands for downloading previous versions of elements in changeset

### DIFF
--- a/Changeset.pm
+++ b/Changeset.pm
@@ -175,4 +175,27 @@ sub download($)
     return $resp->content();
 }
 
+# -----------------------------------------------------------------------------
+# Get element versions from changeset content
+# Paramters: changeset content
+# Returns: array of type/id/version, undef on error
+sub get_element_versions($)
+{
+    my ($content) = @_;
+    my @elements = ();
+
+    open my $fh, '<', \$content;
+    while (<$fh>)
+    {
+        next unless /<(node|way|relation)/;
+        my $type = $1;
+        /id="(\d+)"/;
+        my $id = $1;
+        /version="(\d+)"/;
+        my $version = $1;
+        push @elements, "$type/$id/$version";
+    }
+    return @elements;
+}
+
 1;

--- a/Changeset.pm
+++ b/Changeset.pm
@@ -259,16 +259,9 @@ sub prepare_download_queries(@)
         my $type = $1;
         my $id = $2;
         my $version = $3;
-        $counts{$type} = 0 if !exists $counts{$type};
         $counts{$type}++;
-        if (exists $ivs{$type})
-        {
-            $ivs{$type} .= "," . $id . "v" . $version;
-        }
-        else
-        {
-            $ivs{$type} = $id . "v" . $version;
-        }
+        $ivs{$type} .= "," if exists $ivs{$type};
+        $ivs{$type} .= $id . "v" . $version;
         flush($type) if $counts{$type} > 700 || length($ivs{$type}) > 7500;
     }
     flush($_) for keys %counts;

--- a/Changeset.pm
+++ b/Changeset.pm
@@ -182,7 +182,7 @@ sub download($)
 sub get_element_versions($)
 {
     my ($content) = @_;
-    my @elements = ();
+    my @element_versions = ();
 
     open my $fh, '<', \$content;
     while (<$fh>)
@@ -193,9 +193,27 @@ sub get_element_versions($)
         my $id = $1;
         /version="(\d+)"/;
         my $version = $1;
-        push @elements, "$type/$id/$version";
+        push @element_versions, "$type/$id/$version";
     }
-    return @elements;
+    return @element_versions;
+}
+
+sub get_previous_element_versions(@)
+{
+    my @element_versions = @_;
+    my @previous_element_versions = ();
+
+    foreach (@element_versions)
+    {
+        next unless /(\w+)\/(\d+)\/(\d+)/;
+        my $type = $1;
+        my $id = $2;
+        my $version = $3;
+        $version -= 1;
+        next if $version <= 0;
+        push @previous_element_versions, "$type/$id/$version";
+    }
+    return @previous_element_versions;
 }
 
 1;

--- a/Changeset.pm
+++ b/Changeset.pm
@@ -237,6 +237,35 @@ sub download_elements(@)
     return merge_osm_contents(@contents);
 }
 
+sub get_changeset_summary($)
+{
+    my ($content) = @_;
+    my %counts = ();
+    my %users = ();
+    my %uids = ();
+
+    CORE::open my $fh, '<', \$content;
+    while (<$fh>)
+    {
+        next unless /<(node|way|relation)/;
+        /changeset="([^"]*)"/;
+        my $changeset = $1;
+        $counts{$changeset}++;
+        /user="([^"]*)"/;
+        $users{$changeset} = $1;
+        /uid="([^"]*)"/;
+        $uids{$changeset} = $1;
+    }
+    CORE::close $fh;
+
+    my $result = "# count, changeset, uid, user\n";
+    foreach my $changeset (reverse sort keys %counts)
+    {
+        $result .= $counts{$changeset} . "," . $changeset . "," . $uids{$changeset} . "," . $users{$changeset} . "\n";
+    }
+    return $result;
+}
+
 ###
 
 sub prepare_download_queries(@)

--- a/changeset.pl
+++ b/changeset.pl
@@ -49,6 +49,11 @@ elsif (($ARGV[0] eq "download") && (scalar(@ARGV)==2))
     print Changeset::download($ARGV[1]);
     print "\n";
 }
+elsif (($ARGV[0] eq "download-versions") && (scalar(@ARGV)==2))
+{
+    my $content = Changeset::download($ARGV[1]);
+    print "$_\n" for Changeset::get_element_versions($content);
+}
 else
 {
     print <<EOF;
@@ -58,6 +63,7 @@ Usage:
   $0 upload <id> <content>   to upload changes to an open changeset
   $0 comment <id> <comment>  to comment on an existing changeset
   $0 download <id>           to download and display an existing changeset
+  $0 download-versions <id>  to download and display element versions of a changeset
 EOF
     exit;
 }

--- a/changeset.pl
+++ b/changeset.pl
@@ -67,7 +67,17 @@ elsif (($ARGV[0] eq "download-previous") && (scalar(@ARGV)==2))
     my $content = Changeset::download($ARGV[1]);
     my @element_versions = Changeset::get_element_versions($content);
     my @previous_element_versions = Changeset::get_previous_element_versions(@element_versions);
-    print Changeset::download_elements(@previous_element_versions);
+    my $previous_content = Changeset::download_elements(@previous_element_versions);
+    print $previous_content;
+}
+elsif (($ARGV[0] eq "download-previous-summary") && (scalar(@ARGV)==2))
+{
+    my $content = Changeset::download($ARGV[1]);
+    my @element_versions = Changeset::get_element_versions($content);
+    my @previous_element_versions = Changeset::get_previous_element_versions(@element_versions);
+    my $previous_content = Changeset::download_elements(@previous_element_versions);
+    my $previous_summary = Changeset::get_changeset_summary($previous_content);
+    print $previous_summary;
 }
 else
 {
@@ -81,6 +91,7 @@ Usage:
   $0 download-versions <id>             to download and display element versions of a changeset
   $0 download-previous <id>             to download and display previous elements of a changeset
   $0 download-previous-versions <id>    to download and display previous element versions of a changeset
+  $0 download-previous-summary <id>     to display a summary table of previous changesets
 EOF
     exit;
 }

--- a/changeset.pl
+++ b/changeset.pl
@@ -68,7 +68,6 @@ elsif (($ARGV[0] eq "download-previous") && (scalar(@ARGV)==2))
     my @element_versions = Changeset::get_element_versions($content);
     my @previous_element_versions = Changeset::get_previous_element_versions(@element_versions);
     print Changeset::download_elements(@previous_element_versions);
-    print "\n";
 }
 else
 {

--- a/changeset.pl
+++ b/changeset.pl
@@ -52,18 +52,27 @@ elsif (($ARGV[0] eq "download") && (scalar(@ARGV)==2))
 elsif (($ARGV[0] eq "download-versions") && (scalar(@ARGV)==2))
 {
     my $content = Changeset::download($ARGV[1]);
-    print "$_\n" for Changeset::get_element_versions($content);
+    my @element_versions = Changeset::get_element_versions($content);
+    print "$_\n" for @element_versions;
+}
+elsif (($ARGV[0] eq "download-previous-versions") && (scalar(@ARGV)==2))
+{
+    my $content = Changeset::download($ARGV[1]);
+    my @element_versions = Changeset::get_element_versions($content);
+    my @previous_element_versions = Changeset::get_previous_element_versions(@element_versions);
+    print "$_\n" for @previous_element_versions;
 }
 else
 {
     print <<EOF;
 Usage: 
-  $0 create [<comment>]      to create a changeset; returns ID created
-  $0 close <id> [<comment>]  to close a changeset and optionally set comment
-  $0 upload <id> <content>   to upload changes to an open changeset
-  $0 comment <id> <comment>  to comment on an existing changeset
-  $0 download <id>           to download and display an existing changeset
-  $0 download-versions <id>  to download and display element versions of a changeset
+  $0 create [<comment>]                 to create a changeset; returns ID created
+  $0 close <id> [<comment>]             to close a changeset and optionally set comment
+  $0 upload <id> <content>              to upload changes to an open changeset
+  $0 comment <id> <comment>             to comment on an existing changeset
+  $0 download <id>                      to download and display an existing changeset
+  $0 download-versions <id>             to download and display element versions of a changeset
+  $0 download-previous-versions <id>    to download and display previous element versions of a changeset
 EOF
     exit;
 }

--- a/changeset.pl
+++ b/changeset.pl
@@ -62,6 +62,14 @@ elsif (($ARGV[0] eq "download-previous-versions") && (scalar(@ARGV)==2))
     my @previous_element_versions = Changeset::get_previous_element_versions(@element_versions);
     print "$_\n" for @previous_element_versions;
 }
+elsif (($ARGV[0] eq "download-previous") && (scalar(@ARGV)==2))
+{
+    my $content = Changeset::download($ARGV[1]);
+    my @element_versions = Changeset::get_element_versions($content);
+    my @previous_element_versions = Changeset::get_previous_element_versions(@element_versions);
+    print Changeset::download_elements(@previous_element_versions);
+    print "\n";
+}
 else
 {
     print <<EOF;
@@ -72,6 +80,7 @@ Usage:
   $0 comment <id> <comment>             to comment on an existing changeset
   $0 download <id>                      to download and display an existing changeset
   $0 download-versions <id>             to download and display element versions of a changeset
+  $0 download-previous <id>             to download and display previous elements of a changeset
   $0 download-previous-versions <id>    to download and display previous element versions of a changeset
 EOF
     exit;


### PR DESCRIPTION
can show a list of previous changesets to help reverting multi-layer vandalism