### PR TITLE
Changeset dependency graph

### DIFF
--- a/Changeset.pm
+++ b/Changeset.pm
@@ -277,12 +277,12 @@ sub get_changeset_summary($)
     }
     CORE::close $fh;
 
-    my $result;
+    my @result;
     foreach my $changeset (sort { $b <=> $a } keys %counts)
     {
-        $result .= $counts{$changeset} . "," . $changeset . "," . $uids{$changeset} . "," . $users{$changeset} . "\n";
+        push @result, $counts{$changeset} . "," . $changeset . "," . $uids{$changeset} . "," . $users{$changeset};
     }
-    return $result;
+    return @result;
 }
 
 ###

--- a/Changeset.pm
+++ b/Changeset.pm
@@ -166,7 +166,7 @@ sub upload($$)
 sub download($)
 {
     my $csid = shift;
-    my $resp = OsmApi::get("changeset/$csid/download");
+    my $resp = OsmApi::get("changeset/$csid/download?show_redactions=true", "", 1);
     if (!$resp->is_success)
     {
         print STDERR "changeset $csid cannot be retrieved: ".$resp->status_line."\n";
@@ -340,7 +340,7 @@ sub run_download_queries($@)
     my @contents = ();
     foreach my $query (@queries)
     {
-        my $resp = OsmApi::get($query);
+        my $resp = OsmApi::get("$query&show_redactions=true", "", 1);
         if (!$resp->is_success)
         {
             print STDERR "$relation element versions cannot be retrieved: ".$resp->status_line."\n";

--- a/Changeset.pm
+++ b/Changeset.pm
@@ -265,12 +265,13 @@ sub get_next_element_versions(@)
     return @next_element_versions;
 }
 
-sub download_elements(@)
+sub download_elements($@)
 {
+    my $relation = shift;
     my @element_versions = @_;
 
     my @queries = prepare_download_queries(1, @element_versions);
-    return run_download_queries("previous", @queries);
+    return run_download_queries($relation, @queries);
 }
 
 sub get_changeset_summary($)

--- a/Changeset.pm
+++ b/Changeset.pm
@@ -176,6 +176,23 @@ sub download($)
 }
 
 # -----------------------------------------------------------------------------
+# Downloads changeset metadata.
+# Paramters: changeset id
+# Returns: changeset metadata contents as string, undef on error
+
+sub get($)
+{
+    my $csid = shift;
+    my $resp = OsmApi::get("changeset/$csid?include_discussion=true");
+    if (!$resp->is_success)
+    {
+        print STDERR "metadata of changeset $csid cannot be retrieved: ".$resp->status_line."\n";
+        return undef;
+    }
+    return $resp->content();
+}
+
+# -----------------------------------------------------------------------------
 # Get element versions from changeset content
 # Paramters: changeset content
 # Returns: array of type/id/version, undef on error

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -1,0 +1,114 @@
+#!/usr/bin/perl
+
+package ChangesetGraph;
+
+use strict;
+use warnings;
+use List::Util qw(uniqnum);
+
+sub generate($)
+{
+    my ($dirname) = @_;
+    my ($js_nodes, $js_links) = read_js_data($dirname);
+    write_html($dirname, $js_nodes, $js_links);
+}
+
+###
+
+sub read_js_data($)
+{
+    my ($dirname) = @_;
+
+    my %nodes_in_edges = read_nodes_edges($dirname, "in");
+    my %nodes_out_edges = read_nodes_edges($dirname, "out");
+
+    my @cids = sort { $a <=> $b } uniqnum keys(%nodes_in_edges), keys(%nodes_out_edges);
+    my %all_cids;
+    my %merged_edges;
+    foreach my $cid (@cids)
+    {
+        $all_cids{$cid} = 1;
+        if ($nodes_in_edges{$cid})
+        {
+            my @edges = @{$nodes_in_edges{$cid}};
+            foreach my $edge (@edges)
+            {
+                my ($weight, $in_cid) = split ",", $edge;
+                $all_cids{$in_cid} = 1;
+                $merged_edges{$in_cid} = "$weight,$cid";
+            }
+        }
+        if ($nodes_out_edges{$cid})
+        {
+            my @edges = @{$nodes_out_edges{$cid}};
+            foreach my $edge (@edges)
+            {
+                my ($weight, $out_cid) = split ",", $edge;
+                $all_cids{$out_cid} = 1;
+                $merged_edges{$cid} = "$weight,$out_cid";
+            }
+        }
+    }
+
+    my $js_nodes;
+    my $js_links;
+    foreach my $cid (sort { $a <=> $b } keys(%all_cids))
+    {
+        $js_nodes .= "{ id: $cid },\n";
+        my $edge = $merged_edges{$cid};
+        next unless defined($edge);
+        my ($weight, $out_cid) = split ",", $edge;
+        $js_links .= "{ source: $cid, target: $out_cid, weight: $weight },\n";
+    }
+
+    return $js_nodes, $js_links;
+}
+
+sub read_nodes_edges($$)
+{
+    my ($dirname, $direction) = @_;
+    my %nodes_edges;
+
+    foreach my $filename (glob qq{"$dirname/*.$direction"})
+    {
+        next unless $filename =~ qr/(\d+)\.${direction}$/;
+        my $cid = $1;
+        open my $fh, '<', $filename;
+        chomp(my @lines = <$fh>);
+        close $fh;
+        $nodes_edges{$cid} = \@lines;
+    }
+    return %nodes_edges;
+}
+
+sub write_html($$$)
+{
+    my ($dirname, $js_nodes, $js_links) = @_;
+    my $fh;
+
+    open $fh, '<', $FindBin::Bin . "/graph.js";
+    my $js_draw_graph = do { local $/; <$fh> };
+    close $fh;
+
+    open $fh, '>', "$dirname/index.html";
+    print $fh <<EOF;
+<head>
+<style> body { margin: 0; } </style>
+<script src="https://unpkg.com/force-graph\@1.43.3/dist/force-graph.min.js"></script>
+</head>
+<body>
+<div id="graph"></div>
+<script>
+const gData = {
+nodes: [
+$js_nodes],
+links: [
+$js_links],
+};
+$js_draw_graph</script>
+</body>
+EOF
+    close $fh;
+}
+
+1;

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -5,6 +5,7 @@ package ChangesetGraph;
 use strict;
 use warnings;
 use List::Util qw(uniqnum);
+use XML::Twig;
 
 sub generate($$$$)
 {
@@ -100,18 +101,12 @@ sub read_nodes_data($)
     {
         next unless $filename =~ qr/(\d+)\.osm$/;
         my $cid = $1;
-        open my $fh, '<', $filename;
-        while (<$fh>)
-        {
-            next unless /<changeset/;
-            /user="([^"]*)"/;
-            my $user = $1;
-            /uid="([^"]*)"/;
-            my $uid = $1;
-            $nodes_data{$cid} = [$uid, $user];
-            last;
-        }
-        close $fh;
+        my $twig = XML::Twig->new(keep_encoding => 1)->parsefile($filename);
+        my $changeset = $twig->root->first_child('changeset');
+        $nodes_data{$cid} = [
+            $changeset->att('uid'),
+            $changeset->att('user'),
+        ];
     }
     return %nodes_data;
 }

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -69,9 +69,7 @@ sub read_js_data($)
         if ($node)
         {
             my ($selected, $uid, $user, $comment) = @$node;
-            $user =~ s/"/\\"/g;
-            $comment =~ s/"/\\"/g;
-            $js_nodes .= qq#{ id: $cid, selected: $selected, uid: $uid, user: "$user", comment: "$comment" },\n#;
+            $js_nodes .= "{ id: $cid, selected: $selected, uid: $uid, user: ${\(to_js_string($user))}, comment: ${\(to_js_string($comment))} },\n";
         }
         else
         {
@@ -170,6 +168,14 @@ sub get_option_const($$)
 {
     my ($name, $value) = @_;
     return "const $name = ${\($value ? 'true' : 'false')};";
+}
+
+sub to_js_string($)
+{
+    my ($s) = @_;
+    $s =~ s/\\/\\\\/g;
+    $s =~ s/'/\\'/g;
+    return qq{'$s'};
 }
 
 1;

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -39,7 +39,7 @@ sub read_js_data($)
                 my ($weight, $in_cid, $in_uid, $in_user) = @$edge;
                 $all_cids{$in_cid} = 1;
                 $merged_edges{$in_cid}{$cid} = $weight;
-                $merged_nodes{$in_cid} = [0, $in_uid, $in_user];
+                $merged_nodes{$in_cid} = [0, $in_uid, $in_user, ""];
             }
         }
         if ($nodes_out_edges{$cid})
@@ -50,7 +50,7 @@ sub read_js_data($)
                 my ($weight, $out_cid, $out_uid, $out_user) = @$edge;
                 $all_cids{$out_cid} = 1;
                 $merged_edges{$cid}{$out_cid} = $weight;
-                $merged_nodes{$out_cid} = [0, $out_uid, $out_user];
+                $merged_nodes{$out_cid} = [0, $out_uid, $out_user, ""];
             }
         }
     }
@@ -68,9 +68,10 @@ sub read_js_data($)
         my $node = $merged_nodes{$cid};
         if ($node)
         {
-            my ($selected, $uid, $user) = @$node;
+            my ($selected, $uid, $user, $comment) = @$node;
             $user =~ s/"/\\"/g;
-            $js_nodes .= qq#{ id: $cid, selected: $selected, uid: $uid, user: "$user" },\n#;
+            $comment =~ s/"/\\"/g;
+            $js_nodes .= qq#{ id: $cid, selected: $selected, uid: $uid, user: "$user", comment: "$comment" },\n#;
         }
         else
         {
@@ -103,9 +104,12 @@ sub read_nodes_data($)
         my $cid = $1;
         my $twig = XML::Twig->new(keep_encoding => 1)->parsefile($filename);
         my $changeset = $twig->root->first_child('changeset');
+        my $comment_tag = $changeset->first_child('tag[@k="comment"]');
+        my $comment = $comment_tag ? $comment_tag->att('v') : "";
         $nodes_data{$cid} = [
             $changeset->att('uid'),
             $changeset->att('user'),
+            $comment,
         ];
     }
     return %nodes_data;

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -35,10 +35,10 @@ sub read_js_data($)
             my @edges = @{$nodes_in_edges{$cid}};
             foreach my $edge (@edges)
             {
-                my ($weight, $in_cid, $in_uid, $in_user) = split ",", $edge;
+                my ($weight, $in_cid, $in_uid, $in_user) = @$edge;
                 $all_cids{$in_cid} = 1;
                 $merged_edges{$in_cid}{$cid} = $weight;
-                $merged_nodes{$in_cid} = "0,$in_uid,$in_user";
+                $merged_nodes{$in_cid} = [0, $in_uid, $in_user];
             }
         }
         if ($nodes_out_edges{$cid})
@@ -46,10 +46,10 @@ sub read_js_data($)
             my @edges = @{$nodes_out_edges{$cid}};
             foreach my $edge (@edges)
             {
-                my ($weight, $out_cid, $out_uid, $out_user) = split ",", $edge;
+                my ($weight, $out_cid, $out_uid, $out_user) = @$edge;
                 $all_cids{$out_cid} = 1;
                 $merged_edges{$cid}{$out_cid} = $weight;
-                $merged_nodes{$out_cid} = "0,$out_uid,$out_user";
+                $merged_nodes{$out_cid} = [0, $out_uid, $out_user];
             }
         }
     }
@@ -57,7 +57,7 @@ sub read_js_data($)
     {
         if ($nodes_data{$cid})
         {
-            $merged_nodes{$cid} = "1," . $nodes_data{$cid};
+            $merged_nodes{$cid} = [1, @{$nodes_data{$cid}}];
         }
     }
 
@@ -67,7 +67,7 @@ sub read_js_data($)
         my $node = $merged_nodes{$cid};
         if ($node)
         {
-            my ($selected, $uid, $user) = split ",", $node;
+            my ($selected, $uid, $user) = @$node;
             $user =~ s/"/\\"/g;
             $js_nodes .= qq#{ id: $cid, selected: $selected, uid: $uid, user: "$user" },\n#;
         }
@@ -108,7 +108,7 @@ sub read_nodes_data($)
             my $user = $1;
             /uid="([^"]*)"/;
             my $uid = $1;
-            $nodes_data{$cid} = "$uid,$user";
+            $nodes_data{$cid} = [$uid, $user];
             last;
         }
         close $fh;
@@ -128,7 +128,7 @@ sub read_nodes_edges($$)
         open my $fh, '<', $filename;
         chomp(my @lines = <$fh>);
         close $fh;
-        $nodes_edges{$cid} = \@lines;
+        $nodes_edges{$cid} = [map { [split ","] } @lines];
     }
     return %nodes_edges;
 }

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -6,11 +6,11 @@ use strict;
 use warnings;
 use List::Util qw(uniqnum);
 
-sub generate($)
+sub generate($$$$)
 {
-    my ($dirname) = @_;
+    my ($dirname, $show_cids, $show_users, $show_uids) = @_;
     my ($js_nodes, $js_links) = read_js_data($dirname);
-    write_html($dirname, $js_nodes, $js_links);
+    write_html($dirname, $show_cids, $show_users, $show_uids, $js_nodes, $js_links);
 }
 
 ###
@@ -133,9 +133,9 @@ sub read_nodes_edges($$)
     return %nodes_edges;
 }
 
-sub write_html($$$)
+sub write_html($$$$$$)
 {
-    my ($dirname, $js_nodes, $js_links) = @_;
+    my ($dirname, $show_cids, $show_users, $show_uids, $js_nodes, $js_links) = @_;
     my $fh;
 
     open $fh, '<', $FindBin::Bin . "/graph.js";
@@ -151,6 +151,9 @@ sub write_html($$$)
 <body>
 <div id="graph"></div>
 <script>
+${\(get_option_const('showCids', $show_cids))}
+${\(get_option_const('showUsers', $show_users))}
+${\(get_option_const('showUids', $show_uids))}
 const gData = {
 nodes: [
 $js_nodes],
@@ -162,6 +165,12 @@ $js_draw_graph</script>
 </body>
 EOF
     close $fh;
+}
+
+sub get_option_const($$)
+{
+    my ($name, $value) = @_;
+    return "const $name = ${\($value ? 'true' : 'false')};";
 }
 
 1;

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -9,9 +9,9 @@ use XML::Twig;
 
 sub generate($$$$)
 {
-    my ($dirname, $show_cids, $show_users, $show_uids) = @_;
+    my ($dirname, $show_ids, $show_users, $show_uids) = @_;
     my ($js_nodes, $js_links) = read_js_data($dirname);
-    write_html($dirname, $show_cids, $show_users, $show_uids, $js_nodes, $js_links);
+    write_html($dirname, $show_ids, $show_users, $show_uids, $js_nodes, $js_links);
 }
 
 ###
@@ -174,7 +174,7 @@ sub read_changeset_edges($$$)
 
 sub write_html($$$$$$)
 {
-    my ($dirname, $show_cids, $show_users, $show_uids, $js_nodes, $js_links) = @_;
+    my ($dirname, $show_ids, $show_users, $show_uids, $js_nodes, $js_links) = @_;
     my $fh;
 
     open $fh, '<', $FindBin::Bin . "/graph.js";
@@ -190,7 +190,7 @@ sub write_html($$$$$$)
 <body>
 <div id="graph"></div>
 <script>
-${\(get_option_const('showCids', $show_cids))}
+${\(get_option_const('showIds', $show_ids))}
 ${\(get_option_const('showUsers', $show_users))}
 ${\(get_option_const('showUids', $show_uids))}
 const gData = {

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -157,6 +157,7 @@ $js_nodes],
 links: [
 $js_links],
 };
+
 $js_draw_graph</script>
 </body>
 EOF

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -96,7 +96,7 @@ sub read_nodes_data($)
     my ($dirname) = @_;
     my %nodes_data;
 
-    foreach my $filename (glob qq{"$dirname/*.osm"})
+    foreach my $filename (glob qq{"$dirname/changesets/*.osm"})
     {
         next unless $filename =~ qr/(\d+)\.osm$/;
         my $cid = $1;
@@ -121,7 +121,7 @@ sub read_nodes_edges($$)
     my ($dirname, $direction) = @_;
     my %nodes_edges;
 
-    foreach my $filename (glob qq{"$dirname/*.$direction"})
+    foreach my $filename (glob qq{"$dirname/changesets/*.$direction"})
     {
         next unless $filename =~ qr/(\d+)\.${direction}$/;
         my $cid = $1;

--- a/ChangesetGraph.pm
+++ b/ChangesetGraph.pm
@@ -19,11 +19,13 @@ sub read_js_data($)
 {
     my ($dirname) = @_;
 
+    my %nodes_data = read_nodes_data($dirname);
     my %nodes_in_edges = read_nodes_edges($dirname, "in");
     my %nodes_out_edges = read_nodes_edges($dirname, "out");
 
-    my @cids = sort { $a <=> $b } uniqnum keys(%nodes_in_edges), keys(%nodes_out_edges);
+    my @cids = sort { $a <=> $b } uniqnum keys(%nodes_data), keys(%nodes_in_edges), keys(%nodes_out_edges);
     my %all_cids;
+    my %merged_nodes;
     my %merged_edges;
     foreach my $cid (@cids)
     {
@@ -33,9 +35,10 @@ sub read_js_data($)
             my @edges = @{$nodes_in_edges{$cid}};
             foreach my $edge (@edges)
             {
-                my ($weight, $in_cid) = split ",", $edge;
+                my ($weight, $in_cid, $in_uid, $in_user) = split ",", $edge;
                 $all_cids{$in_cid} = 1;
-                $merged_edges{$in_cid} = "$weight,$cid";
+                $merged_edges{$in_cid}{$cid} = $weight;
+                $merged_nodes{$in_cid} = "0,$in_uid,$in_user";
             }
         }
         if ($nodes_out_edges{$cid})
@@ -43,25 +46,74 @@ sub read_js_data($)
             my @edges = @{$nodes_out_edges{$cid}};
             foreach my $edge (@edges)
             {
-                my ($weight, $out_cid) = split ",", $edge;
+                my ($weight, $out_cid, $out_uid, $out_user) = split ",", $edge;
                 $all_cids{$out_cid} = 1;
-                $merged_edges{$cid} = "$weight,$out_cid";
+                $merged_edges{$cid}{$out_cid} = $weight;
+                $merged_nodes{$out_cid} = "0,$out_uid,$out_user";
             }
+        }
+    }
+    foreach my $cid (@cids)
+    {
+        if ($nodes_data{$cid})
+        {
+            $merged_nodes{$cid} = "1," . $nodes_data{$cid};
         }
     }
 
     my $js_nodes;
-    my $js_links;
     foreach my $cid (sort { $a <=> $b } keys(%all_cids))
     {
-        $js_nodes .= "{ id: $cid },\n";
-        my $edge = $merged_edges{$cid};
-        next unless defined($edge);
-        my ($weight, $out_cid) = split ",", $edge;
-        $js_links .= "{ source: $cid, target: $out_cid, weight: $weight },\n";
+        my $node = $merged_nodes{$cid};
+        if ($node)
+        {
+            my ($selected, $uid, $user) = split ",", $node;
+            $user =~ s/"/\\"/g;
+            $js_nodes .= qq#{ id: $cid, selected: $selected, uid: $uid, user: "$user" },\n#;
+        }
+        else
+        {
+            $js_nodes .= "{ id: $cid, selected: 0 },\n";
+        }
+    }
+
+    my $js_links;
+    foreach my $in_cid (sort { $a <=> $b } keys(%merged_edges))
+    {
+        my %out_edges = %{$merged_edges{$in_cid}};
+        foreach my $out_cid (sort { $a <=> $b } keys(%out_edges))
+        {
+            my $weight = $out_edges{$out_cid};
+            $js_links .= "{ source: $in_cid, target: $out_cid, weight: $weight },\n";
+        }
     }
 
     return $js_nodes, $js_links;
+}
+
+sub read_nodes_data($)
+{
+    my ($dirname) = @_;
+    my %nodes_data;
+
+    foreach my $filename (glob qq{"$dirname/*.osm"})
+    {
+        next unless $filename =~ qr/(\d+)\.osm$/;
+        my $cid = $1;
+        open my $fh, '<', $filename;
+        while (<$fh>)
+        {
+            next unless /<changeset/;
+            /user="([^"]*)"/;
+            my $user = $1;
+            /uid="([^"]*)"/;
+            my $uid = $1;
+            $nodes_data{$cid} = "$uid,$user";
+            last;
+        }
+        close $fh;
+    }
+    return %nodes_data;
 }
 
 sub read_nodes_edges($$)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Package Contents
 | `batch_redaction.pl`  | `BatchRedaction.pm`  | applies redactions to a list of elements  |
 | `block.pl` | `Block.pm`  | creates user blocks  |
 | `changeset.pl`  | `Changeset.pm`  | opens and closes changesets  |
+| `changeset_graph.pl`  | `ChangesetGraph.pm`  | draws changeset dependency graph  |
 | `complex_revert.pl`  |   | reverts a group of interdependent changesets  |
 | `delete.pl`  | `Delete.pm`  | deletes or redacts an object  |
 | `modify.pl`  | `Modify.pm`  | modifies tags of an object  |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Design "Philosophy"
 
 Most functionality is implemented as individual Perl modules (`.pm`). They do not have a namespace because we want people to be able to run everything from the current directory. If you create a Perl module named `Osm::Api`, then it has to reside in a subdirectory named `Osm` which tends to get confusing, at least for me.
 
-We're not using any libraries for XML reading and writing in most of the scripts, with the exception of `note.pl`, just plain regular expressions.
+We're not using any libraries for XML reading and writing in most of the scripts, just plain regular expressions.
 
 We're not creating any OO interfaces.
 

--- a/changeset.pl
+++ b/changeset.pl
@@ -147,12 +147,12 @@ sub download_siblings($$$@)
         return 1;
     }
 
-    my $other_summary = Changeset::get_changeset_summary($other_content);
+    my @other_summary = Changeset::get_changeset_summary($other_content);
     if ($subcommand eq "-summary")
     {
         print "# summary of changesets " . ($is_previous ? "preceding" : "following") . " $cid\n";
         print "# count, changeset, uid, user\n";
-        print $other_summary;
+        print "$_\n" for @other_summary;
         return 1;
     }
 }

--- a/changeset.pl
+++ b/changeset.pl
@@ -149,7 +149,7 @@ sub download_siblings($$$@)
         return 1;
     }
 
-    my $other_content = Changeset::download_elements(@other_element_versions);
+    my $other_content = Changeset::download_elements(($is_previous ? "previous" : "next"), @other_element_versions);
     if ($subcommand eq "")
     {
         print $other_content;

--- a/changeset.pl
+++ b/changeset.pl
@@ -14,6 +14,7 @@ my @regular_commands = (
     "close <id> [<comment>]", "close a changeset and optionally set comment",
     "upload <id> <content>",  "upload changes to an open changeset",
     "comment <id> <comment>", "comment on an existing changeset",
+    "get <id>",               "load and print changeset metadata XML",
 );
 
 if ($ARGV[0] eq "create")
@@ -57,6 +58,14 @@ if (($ARGV[0] eq "comment") && (scalar(@ARGV)==3))
     {
         print "comment added.\n";
     }
+    exit;
+}
+
+if (($ARGV[0] eq "get") && (scalar(@ARGV)==2))
+{
+    my $content = Changeset::get($ARGV[1]);
+    print $content;
+    print "\n";
     exit;
 }
 

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -3,10 +3,21 @@
 use strict;
 use FindBin;
 use lib $FindBin::Bin;
+use Getopt::Long;
 use Changeset;
 use ChangesetGraph;
 
-if (($ARGV[0] eq "add") && (scalar(@ARGV)==2))
+my $graph_cids = 1;
+my $graph_users = 0;
+my $graph_uids = 0;
+
+my $correct_options = GetOptions(
+    "graph-cids!" => \$graph_cids,
+    "graph-users!" => \$graph_users,
+    "graph-uids!" => \$graph_uids,
+);
+
+if ($correct_options && ($ARGV[0] eq "add") && (scalar(@ARGV)==2))
 {
     my ($command, $cid) = @ARGV;
     my $dirname = "graph";
@@ -26,22 +37,27 @@ if (($ARGV[0] eq "add") && (scalar(@ARGV)==2))
     my @next_element_versions = Changeset::get_next_element_versions(@element_versions);
     write_edges("$dirname/$cid.out", @next_element_versions);
 
-    ChangesetGraph::generate($dirname);
+    ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
     exit;
 }
 
-if (($ARGV[0] eq "redraw") && (scalar(@ARGV)==1))
+if ($correct_options && ($ARGV[0] eq "redraw") && (scalar(@ARGV)==1))
 {
     my $dirname = "graph";
 
-    ChangesetGraph::generate($dirname);
+    ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
     exit;
 }
 
 print <<EOF;
 Usage:
-  $0 add <id>    add changeset
-  $0 redraw      redraw graph from added changesets
+  $0 add <id> <options>               add changeset
+  $0 redraw <options>                 redraw graph from added changesets
+
+options:
+  --graph-cids  | --no-graph-cids     [don't] show changeset ids on graph
+  --graph-users | --no-graph-users    [don't] show usernames on graph
+  --graph-uids  | --no-graph-uids     [don't] show user ids on graph
 EOF
 
 sub write_node($$)

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -12,6 +12,10 @@ if (($ARGV[0] eq "add") && (scalar(@ARGV)==2))
     my $dirname = "graph";
     mkdir $dirname unless -d $dirname;
 
+    my $metadata = Changeset::get($cid);
+    die unless defined($metadata);
+    write_node("$dirname/$cid.osm", $metadata);
+
     my $content = Changeset::download($cid);
     die unless defined($content);
     my @element_versions = Changeset::get_element_versions($content);
@@ -26,10 +30,27 @@ if (($ARGV[0] eq "add") && (scalar(@ARGV)==2))
     exit;
 }
 
+if (($ARGV[0] eq "redraw") && (scalar(@ARGV)==1))
+{
+    my $dirname = "graph";
+
+    ChangesetGraph::generate($dirname);
+    exit;
+}
+
 print <<EOF;
 Usage:
   $0 add <id>    add changeset
+  $0 redraw      redraw graph from added changesets
 EOF
+
+sub write_node($$)
+{
+    my ($filename, $metadata) = @_;
+    open my $fh, '>', $filename;
+    print $fh $metadata;
+    close $fh;
+}
 
 sub write_edges($@)
 {

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -19,9 +19,9 @@ my $correct_options = GetOptions(
     "graph-uids!" => \$graph_uids,
 );
 
-if ($correct_options && ($ARGV[0] eq "add") && (scalar(@ARGV)==2))
+if ($correct_options && ($ARGV[0] eq "add") && ($ARGV[1] eq "changeset") && (scalar(@ARGV)==3))
 {
-    my ($command, $cid) = @ARGV;
+    my ($command, $type, $cid) = @ARGV;
     mkdir $dirname unless -d $dirname;
     mkdir "$dirname/changesets" unless -d "$dirname/changesets";
 
@@ -43,9 +43,9 @@ if ($correct_options && ($ARGV[0] eq "add") && (scalar(@ARGV)==2))
     exit;
 }
 
-if ($correct_options && ($ARGV[0] eq "remove") && (scalar(@ARGV)==2))
+if ($correct_options && ($ARGV[0] eq "remove") && ($ARGV[1] eq "changeset") && (scalar(@ARGV)==3))
 {
-    my ($command, $cid) = @ARGV;
+    my ($command, $type, $cid) = @ARGV;
     mkdir $dirname unless -d $dirname;
     mkdir "$dirname/changesets" unless -d "$dirname/changesets";
 
@@ -65,8 +65,8 @@ if ($correct_options && ($ARGV[0] eq "redraw") && (scalar(@ARGV)==1))
 
 print <<EOF;
 Usage:
-  $0 add <id> <options>               add changeset to graph
-  $0 remove <id> <options>            remove changeset from graph
+  $0 add changeset <id> <options>     add changeset to graph
+  $0 remove changeset <id> <options>  remove changeset from graph
   $0 redraw <options>                 redraw graph from added changesets
 
 options:

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -33,10 +33,10 @@ if ($correct_options && ($ARGV[0] eq "add") && (scalar(@ARGV)==2))
     my @element_versions = Changeset::get_element_versions($content);
 
     my @previous_element_versions = Changeset::get_previous_element_versions(@element_versions);
-    write_edges("$dirname/$cid.in", @previous_element_versions);
+    write_edges("previous", "$dirname/$cid.in", @previous_element_versions);
 
     my @next_element_versions = Changeset::get_next_element_versions(@element_versions);
-    write_edges("$dirname/$cid.out", @next_element_versions);
+    write_edges("next", "$dirname/$cid.out", @next_element_versions);
 
     ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
     exit;
@@ -82,12 +82,13 @@ sub write_node($$)
     close $fh;
 }
 
-sub write_edges($@)
+sub write_edges($$@)
 {
+    my $relation = shift;
     my $filename = shift;
     my @other_element_versions = @_;
 
-    my $other_content = Changeset::download_elements(@other_element_versions);
+    my $other_content = Changeset::download_elements($relation, @other_element_versions);
     my @other_summary = Changeset::get_changeset_summary($other_content);
     open my $fh, '>', $filename;
     print $fh "$_\n" for @other_summary;

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -42,6 +42,19 @@ if ($correct_options && ($ARGV[0] eq "add") && (scalar(@ARGV)==2))
     exit;
 }
 
+if ($correct_options && ($ARGV[0] eq "remove") && (scalar(@ARGV)==2))
+{
+    my ($command, $cid) = @ARGV;
+    mkdir $dirname unless -d $dirname;
+
+    unlink "$dirname/$cid.osm";
+    unlink "$dirname/$cid.in";
+    unlink "$dirname/$cid.out";
+
+    ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
+    exit;
+}
+
 if ($correct_options && ($ARGV[0] eq "redraw") && (scalar(@ARGV)==1))
 {
     ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
@@ -50,7 +63,8 @@ if ($correct_options && ($ARGV[0] eq "redraw") && (scalar(@ARGV)==1))
 
 print <<EOF;
 Usage:
-  $0 add <id> <options>               add changeset
+  $0 add <id> <options>               add changeset to graph
+  $0 remove <id> <options>            remove changeset from graph
   $0 redraw <options>                 redraw graph from added changesets
 
 options:

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -3,98 +3,42 @@
 use strict;
 use FindBin;
 use lib $FindBin::Bin;
-use List::Util qw(uniqnum);
 use Changeset;
+use ChangesetGraph;
 
-my $dirname = "graph";
-mkdir $dirname unless -d $dirname;
-
-my %nodes_in_edges = read_graph_nodes_edges($dirname, "in");
-my %nodes_out_edges = read_graph_nodes_edges($dirname, "out");
-
-my @cids = sort { $a <=> $b } uniqnum keys(%nodes_in_edges), keys(%nodes_out_edges);
-my %all_cids;
-my %merged_edges;
-foreach my $cid (@cids)
+if (($ARGV[0] eq "add") && (scalar(@ARGV)==2))
 {
-    $all_cids{$cid} = 1;
-    if ($nodes_in_edges{$cid})
-    {
-        my @edges = @{$nodes_in_edges{$cid}};
-        foreach my $edge (@edges)
-        {
-            my ($weight, $in_cid) = split ",", $edge;
-            $all_cids{$in_cid} = 1;
-            $merged_edges{$in_cid} = "$weight,$cid";
-        }
-    }
-    if ($nodes_out_edges{$cid})
-    {
-        my @edges = @{$nodes_out_edges{$cid}};
-        foreach my $edge (@edges)
-        {
-            my ($weight, $out_cid) = split ",", $edge;
-            $all_cids{$out_cid} = 1;
-            $merged_edges{$cid} = "$weight,$out_cid";
-        }
-    }
+    my ($command, $cid) = @ARGV;
+    my $dirname = "graph";
+    mkdir $dirname unless -d $dirname;
+
+    my $content = Changeset::download($cid);
+    die unless defined($content);
+    my @element_versions = Changeset::get_element_versions($content);
+
+    my @previous_element_versions = Changeset::get_previous_element_versions(@element_versions);
+    write_edges("$dirname/$cid.in", @previous_element_versions);
+
+    my @next_element_versions = Changeset::get_next_element_versions(@element_versions);
+    write_edges("$dirname/$cid.out", @next_element_versions);
+
+    ChangesetGraph::generate($dirname);
+    exit;
 }
 
-my $js_nodes;
-my $js_links;
-foreach my $cid (sort { $a <=> $b } keys(%all_cids))
-{
-    $js_nodes .= "{ id: $cid },\n";
-    my $edge = $merged_edges{$cid};
-    next unless defined($edge);
-    my ($weight, $out_cid) = split ",", $edge;
-    $js_links .= "{ source: $cid, target: $out_cid, weight: $weight },\n";
-}
-
-write_graph_html($dirname, $js_nodes, $js_links);
-
-sub read_graph_nodes_edges($$)
-{
-    my ($dirname, $direction) = @_;
-    my %nodes_edges;
-
-    foreach my $filename (glob qq{"$dirname/*.$direction"})
-    {
-        next unless $filename =~ qr/(\d+)\.${direction}$/;
-        my $cid = $1;
-        open my $fh, '<', $filename;
-        chomp(my @lines = <$fh>);
-        close $fh;
-        $nodes_edges{$cid} = \@lines;
-    }
-    return %nodes_edges;
-}
-
-sub write_graph_html($$$)
-{
-    my ($dirname, $js_nodes, $js_links) = @_;
-
-    open my $fh, '<', $FindBin::Bin . "/graph.js";
-    my $js_draw_graph = do { local $/; <$fh> };
-    close $fh;
-
-    open my $fh, '>', "$dirname/graph.html";
-    print $fh <<EOF;
-<head>
-<style> body { margin: 0; } </style>
-<script src="https://unpkg.com/force-graph\@1.43.3/dist/force-graph.min.js"></script>
-</head>
-<body>
-<div id="graph"></div>
-<script>
-const gData = {
-nodes: [
-$js_nodes],
-links: [
-$js_links],
-};
-$js_draw_graph</script>
-</body>
+print <<EOF;
+Usage:
+  $0 add <id>    add changeset
 EOF
+
+sub write_edges($@)
+{
+    my $filename = shift;
+    my @other_element_versions = @_;
+
+    my $other_content = Changeset::download_elements(@other_element_versions);
+    my @other_summary = Changeset::get_changeset_summary($other_content);
+    open my $fh, '>', $filename;
+    print $fh "$_\n" for @other_summary;
     close $fh;
 }

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -23,20 +23,21 @@ if ($correct_options && ($ARGV[0] eq "add") && (scalar(@ARGV)==2))
 {
     my ($command, $cid) = @ARGV;
     mkdir $dirname unless -d $dirname;
+    mkdir "$dirname/changesets" unless -d "$dirname/changesets";
 
     my $metadata = Changeset::get($cid);
     die unless defined($metadata);
-    write_node("$dirname/$cid.osm", $metadata);
+    write_node("$dirname/changesets/$cid.osm", $metadata);
 
     my $content = Changeset::download($cid);
     die unless defined($content);
     my @element_versions = Changeset::get_element_versions($content);
 
     my @previous_element_versions = Changeset::get_previous_element_versions(@element_versions);
-    write_edges("previous", "$dirname/$cid.in", @previous_element_versions);
+    write_edges("previous", "$dirname/changesets/$cid.in", @previous_element_versions);
 
     my @next_element_versions = Changeset::get_next_element_versions(@element_versions);
-    write_edges("next", "$dirname/$cid.out", @next_element_versions);
+    write_edges("next", "$dirname/changesets/$cid.out", @next_element_versions);
 
     ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
     exit;
@@ -46,10 +47,11 @@ if ($correct_options && ($ARGV[0] eq "remove") && (scalar(@ARGV)==2))
 {
     my ($command, $cid) = @ARGV;
     mkdir $dirname unless -d $dirname;
+    mkdir "$dirname/changesets" unless -d "$dirname/changesets";
 
-    unlink "$dirname/$cid.osm";
-    unlink "$dirname/$cid.in";
-    unlink "$dirname/$cid.out";
+    unlink "$dirname/changesets/$cid.osm";
+    unlink "$dirname/changesets/$cid.in";
+    unlink "$dirname/changesets/$cid.out";
 
     ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
     exit;

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -51,7 +51,7 @@ if ($correct_options && ($ARGV[0] eq "add") && $types{$ARGV[1]} && (scalar(@ARGV
         my $subdirname = "$dirname/${type}s";
         mkdir $subdirname unless -d $subdirname;
 
-        my $resp = OsmApi::get("$type/$id/history");
+        my $resp = OsmApi::get("$type/$id/history?show_redactions=true", "", 1);
         if (!$resp->is_success)
         {
             print STDERR "history of $type $id cannot be retrieved: ".$resp->status_line."\n";

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -7,11 +7,13 @@ use Getopt::Long;
 use Changeset;
 use ChangesetGraph;
 
+my $dirname = "graph";
 my $graph_cids = 1;
 my $graph_users = 0;
 my $graph_uids = 0;
 
 my $correct_options = GetOptions(
+    "directory|output=s" => \$dirname,
     "graph-cids!" => \$graph_cids,
     "graph-users!" => \$graph_users,
     "graph-uids!" => \$graph_uids,
@@ -20,7 +22,6 @@ my $correct_options = GetOptions(
 if ($correct_options && ($ARGV[0] eq "add") && (scalar(@ARGV)==2))
 {
     my ($command, $cid) = @ARGV;
-    my $dirname = "graph";
     mkdir $dirname unless -d $dirname;
 
     my $metadata = Changeset::get($cid);
@@ -43,8 +44,6 @@ if ($correct_options && ($ARGV[0] eq "add") && (scalar(@ARGV)==2))
 
 if ($correct_options && ($ARGV[0] eq "redraw") && (scalar(@ARGV)==1))
 {
-    my $dirname = "graph";
-
     ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
     exit;
 }
@@ -55,6 +54,7 @@ Usage:
   $0 redraw <options>                 redraw graph from added changesets
 
 options:
+  --directory <directory>             directory for changeset data and graph html file
   --graph-cids  | --no-graph-cids     [don't] show changeset ids on graph
   --graph-users | --no-graph-users    [don't] show usernames on graph
   --graph-uids  | --no-graph-uids     [don't] show user ids on graph

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -1,0 +1,101 @@
+#!/usr/bin/perl
+
+use strict;
+use FindBin;
+use lib $FindBin::Bin;
+use List::Util qw(uniqnum);
+use Changeset;
+
+my $dirname = "graph";
+mkdir $dirname unless -d $dirname;
+
+my %nodes_in_edges = read_graph_nodes_edges($dirname, "in");
+my %nodes_out_edges = read_graph_nodes_edges($dirname, "out");
+
+my @cids = sort { $a <=> $b } uniqnum keys(%nodes_in_edges), keys(%nodes_out_edges);
+my %all_cids;
+my %merged_edges;
+foreach my $cid (@cids)
+{
+    $all_cids{$cid} = 1;
+    if ($nodes_in_edges{$cid})
+    {
+        my @edges = @{$nodes_in_edges{$cid}};
+        foreach my $edge (@edges)
+        {
+            my ($weight, $in_cid) = split ",", $edge;
+            $all_cids{$in_cid} = 1;
+            $merged_edges{$in_cid} = "$weight,$cid";
+        }
+    }
+    if ($nodes_out_edges{$cid})
+    {
+        my @edges = @{$nodes_out_edges{$cid}};
+        foreach my $edge (@edges)
+        {
+            my ($weight, $out_cid) = split ",", $edge;
+            $all_cids{$out_cid} = 1;
+            $merged_edges{$cid} = "$weight,$out_cid";
+        }
+    }
+}
+
+my $js_nodes;
+my $js_links;
+foreach my $cid (sort { $a <=> $b } keys(%all_cids))
+{
+    $js_nodes .= "{ id: $cid },\n";
+    my $edge = $merged_edges{$cid};
+    next unless defined($edge);
+    my ($weight, $out_cid) = split ",", $edge;
+    $js_links .= "{ source: $cid, target: $out_cid, weight: $weight },\n";
+}
+
+write_graph_html($dirname, $js_nodes, $js_links);
+
+sub read_graph_nodes_edges($$)
+{
+    my ($dirname, $direction) = @_;
+    my %nodes_edges;
+
+    foreach my $filename (glob qq{"$dirname/*.$direction"})
+    {
+        next unless $filename =~ qr/(\d+)\.${direction}$/;
+        my $cid = $1;
+        open my $fh, '<', $filename;
+        chomp(my @lines = <$fh>);
+        close $fh;
+        $nodes_edges{$cid} = \@lines;
+    }
+    return %nodes_edges;
+}
+
+sub write_graph_html($$$)
+{
+    my ($dirname, $js_nodes, $js_links) = @_;
+
+    open my $fh, '>', "$dirname/graph.html";
+    print $fh <<EOF;
+<head>
+<style> body { margin: 0; } </style>
+<script src="https://unpkg.com/force-graph\@1.43.3/dist/force-graph.min.js"></script>
+</head>
+<body>
+<div id="graph"></div>
+<script>
+const gData = {
+nodes: [
+$js_nodes],
+links: [
+$js_links],
+};
+const Graph = ForceGraph()
+(document.getElementById('graph'))
+    .graphData(gData)
+    .linkWidth(({weight}) => 32*Math.log(weight)/Math.log(10000))
+    .linkDirectionalArrowLength(6);
+</script>
+</body>
+EOF
+    close $fh;
+}

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -74,6 +74,10 @@ sub write_graph_html($$$)
 {
     my ($dirname, $js_nodes, $js_links) = @_;
 
+    open my $fh, '<', $FindBin::Bin . "/graph.js";
+    my $js_draw_graph = do { local $/; <$fh> };
+    close $fh;
+
     open my $fh, '>', "$dirname/graph.html";
     print $fh <<EOF;
 <head>
@@ -89,12 +93,7 @@ $js_nodes],
 links: [
 $js_links],
 };
-const Graph = ForceGraph()
-(document.getElementById('graph'))
-    .graphData(gData)
-    .linkWidth(({weight}) => 32*Math.log(weight)/Math.log(10000))
-    .linkDirectionalArrowLength(6);
-</script>
+$js_draw_graph</script>
 </body>
 EOF
     close $fh;

--- a/changeset_graph.pl
+++ b/changeset_graph.pl
@@ -9,13 +9,13 @@ use Changeset;
 use ChangesetGraph;
 
 my $dirname = "graph";
-my $graph_cids = 1;
+my $graph_ids = 1;
 my $graph_users = 0;
 my $graph_uids = 0;
 
 my $correct_options = GetOptions(
     "directory|output=s" => \$dirname,
-    "graph-cids!" => \$graph_cids,
+    "graph-ids!" => \$graph_ids,
     "graph-users!" => \$graph_users,
     "graph-uids!" => \$graph_uids,
 );
@@ -60,7 +60,7 @@ if ($correct_options && ($ARGV[0] eq "add") && $types{$ARGV[1]} && (scalar(@ARGV
         write_file("$subdirname/$id.osm", $resp->content());
     }
 
-    ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
+    ChangesetGraph::generate($dirname, $graph_ids, $graph_users, $graph_uids);
     exit;
 }
 
@@ -82,13 +82,13 @@ if ($correct_options && ($ARGV[0] eq "remove") && $types{$ARGV[1]} && (scalar(@A
         unlink "$subdirname/$id.osm";
     }
 
-    ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
+    ChangesetGraph::generate($dirname, $graph_ids, $graph_users, $graph_uids);
     exit;
 }
 
 if ($correct_options && ($ARGV[0] eq "redraw") && (scalar(@ARGV)==1))
 {
-    ChangesetGraph::generate($dirname, $graph_cids, $graph_users, $graph_uids);
+    ChangesetGraph::generate($dirname, $graph_ids, $graph_users, $graph_uids);
     exit;
 }
 
@@ -105,8 +105,8 @@ type:
   relation
 
 options:
-  --directory <directory>             directory for changeset data and graph html file
-  --graph-cids  | --no-graph-cids     [don't] show changeset ids on graph
+  --directory <directory>             directory for changeset/element data and graph html file
+  --graph-ids   | --no-graph-ids      [don't] show changeset/element ids on graph
   --graph-users | --no-graph-users    [don't] show usernames on graph
   --graph-uids  | --no-graph-uids     [don't] show user ids on graph
 EOF

--- a/graph.js
+++ b/graph.js
@@ -1,3 +1,12 @@
+let minUid = +Infinity;
+let maxUid = -Infinity;
+for (const node of gData.nodes) {
+    const uid = node.uid;
+    if (!uid) continue;
+    if (uid < minUid) minUid = uid;
+    if (uid > maxUid) maxUid = uid;
+}
+
 const Graph = ForceGraph()
 (document.getElementById('graph'))
     .graphData(gData)
@@ -21,7 +30,12 @@ const Graph = ForceGraph()
 
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
-        ctx.fillStyle = '#3183ba';
+        if (node.uid && maxUid > minUid) {
+            const heat = (node.uid - minUid) / (maxUid - minUid);
+            ctx.fillStyle = `rgb(${100 * heat}%, 20%, ${100 * (1 - heat)}%)`;
+        } else {
+            ctx.fillStyle = `rgb(100%, 20%, 0%)`;
+        }
         for (let i = 0; i < labels.length; i++) {
             const label = labels[i];
             const iOffset = i - (labels.length - 1) / 2;

--- a/graph.js
+++ b/graph.js
@@ -2,4 +2,27 @@ const Graph = ForceGraph()
 (document.getElementById('graph'))
     .graphData(gData)
     .linkWidth(({weight}) => 32*Math.log(weight)/Math.log(10000))
-    .linkDirectionalArrowLength(6);
+    .linkDirectionalArrowLength(6)
+    // https://github.com/vasturiano/force-graph/blob/master/example/text-nodes/index.html
+    .nodeCanvasObject((node, ctx, globalScale) => {
+        const label = node.id;
+        const fontSize = 12/globalScale;
+        ctx.font = `${fontSize}px Sans-Serif`;
+        const textWidth = ctx.measureText(label).width;
+        const bckgDimensions = [textWidth, fontSize].map(n => n + fontSize * 0.2); // some padding
+
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
+        ctx.fillRect(node.x - bckgDimensions[0] / 2, node.y - bckgDimensions[1] / 2, ...bckgDimensions);
+
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillStyle = '#3183ba';
+        ctx.fillText(label, node.x, node.y);
+
+        node.__bckgDimensions = bckgDimensions; // to re-use in nodePointerAreaPaint
+    })
+    .nodePointerAreaPaint((node, color, ctx) => {
+        ctx.fillStyle = color;
+        const bckgDimensions = node.__bckgDimensions;
+        bckgDimensions && ctx.fillRect(node.x - bckgDimensions[0] / 2, node.y - bckgDimensions[1] / 2, ...bckgDimensions);
+    });

--- a/graph.js
+++ b/graph.js
@@ -14,12 +14,18 @@ const myGraph = ForceGraph()
     .linkDirectionalArrowLength(6)
     .nodeLabel((node) => {
         const popup = document.createElement('span');
-        const changeset = document.createElement('strong');
+        const item = document.createElement('strong');
         const user = document.createElement('strong');
-        changeset.append(`#`, node.id);
+        item.append(`#`, node.id.substring(1));
         user.append(node.user);
+        const t = node.id[0];
+        let type = '';
+        if (t == 'c') type = 'changeset';
+        if (t == 'n') type = 'node';
+        if (t == 'w') type = 'way';
+        if (t == 'r') type = 'relation';
         popup.append(
-            `changeset `, changeset, document.createElement('br'),
+            `${type} `, item, document.createElement('br'),
             `by `, user, document.createElement('br'),
             `with uid #${node.uid}`
         );
@@ -33,7 +39,9 @@ const myGraph = ForceGraph()
         }
         return popup.innerHTML;
     }).onNodeClick(node => {
-        window.open("https://www.openstreetmap.org/changeset/" + node.id);
+        const t = node.id[0];
+        const id = node.id.substring(1);
+        if (t == 'c') window.open("https://www.openstreetmap.org/changeset/" + id);
     });
 
 if (showCids || showUsers || showUids) {

--- a/graph.js
+++ b/graph.js
@@ -25,4 +25,7 @@ const Graph = ForceGraph()
         ctx.fillStyle = color;
         const bckgDimensions = node.__bckgDimensions;
         bckgDimensions && ctx.fillRect(node.x - bckgDimensions[0] / 2, node.y - bckgDimensions[1] / 2, ...bckgDimensions);
+    })
+    .onNodeClick(node => {
+        window.open("https://www.openstreetmap.org/changeset/" + node.id);
     });

--- a/graph.js
+++ b/graph.js
@@ -12,14 +12,22 @@ const Graph = ForceGraph()
     .graphData(gData)
     .linkWidth(({weight}) => 32*Math.log(weight)/Math.log(10000))
     .linkDirectionalArrowLength(6)
+    .nodeLabel((node) => {
+        const popup = document.createElement('span');
+        const user = document.createElement('strong');
+        user.append(node.user);
+        popup.append(`by `, user, ` (#${node.uid})`);
+        return popup.innerHTML;
+    })
     .nodeCanvasObject((node, ctx, globalScale) => {
-        const labels = [node.id, node.user, node.uid];
+        // const labels = [node.id, node.user, node.uid];
+        const labels = [node.id];
         const fontSize = 12/globalScale;
         ctx.font = `${fontSize}px Sans-Serif`;
         const textWidth = Math.max(...labels.map(label => ctx.measureText(label).width));
         const gap = fontSize * 0.1;
         const nodeWidth = textWidth + 2 * gap;
-        const nodeHeight = 3 * fontSize + 4 * gap;
+        const nodeHeight = labels.length * fontSize + (labels.length + 1) * gap;
 
         if (node.selected) {
             ctx.fillStyle = 'rgba(255, 255, 0, 0.8)';

--- a/graph.js
+++ b/graph.js
@@ -14,9 +14,15 @@ const Graph = ForceGraph()
     .linkDirectionalArrowLength(6)
     .nodeLabel((node) => {
         const popup = document.createElement('span');
+        const changeset = document.createElement('strong');
         const user = document.createElement('strong');
+        changeset.append(`#`, node.id);
         user.append(node.user);
-        popup.append(`by `, user, ` (#${node.uid})`);
+        popup.append(
+            `changeset `, changeset, document.createElement('br'),
+            `by `, user, document.createElement('br'),
+            `with uid #${node.uid}`
+        );
         return popup.innerHTML;
     })
     .nodeCanvasObject((node, ctx, globalScale) => {

--- a/graph.js
+++ b/graph.js
@@ -3,23 +3,33 @@ const Graph = ForceGraph()
     .graphData(gData)
     .linkWidth(({weight}) => 32*Math.log(weight)/Math.log(10000))
     .linkDirectionalArrowLength(6)
-    // https://github.com/vasturiano/force-graph/blob/master/example/text-nodes/index.html
     .nodeCanvasObject((node, ctx, globalScale) => {
-        const label = node.id;
+        const labels = [node.id, node.user, node.uid];
         const fontSize = 12/globalScale;
         ctx.font = `${fontSize}px Sans-Serif`;
-        const textWidth = ctx.measureText(label).width;
-        const bckgDimensions = [textWidth, fontSize].map(n => n + fontSize * 0.2); // some padding
+        const textWidth = Math.max(...labels.map(label => ctx.measureText(label).width));
+        const gap = fontSize * 0.1;
+        const nodeWidth = textWidth + 2 * gap;
+        const nodeHeight = 3 * fontSize + 4 * gap;
 
-        ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
-        ctx.fillRect(node.x - bckgDimensions[0] / 2, node.y - bckgDimensions[1] / 2, ...bckgDimensions);
+        if (node.selected) {
+            ctx.fillStyle = 'rgba(255, 255, 0, 0.8)';
+        } else {
+            ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
+        }
+        ctx.fillRect(node.x - nodeWidth / 2, node.y - nodeHeight / 2, nodeWidth, nodeHeight);
 
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillStyle = '#3183ba';
-        ctx.fillText(label, node.x, node.y);
+        for (let i = 0; i < labels.length; i++) {
+            const label = labels[i];
+            const iOffset = i - (labels.length - 1) / 2;
+            const yOffset = iOffset * (fontSize + gap);
+            ctx.fillText(label, node.x, node.y + yOffset);
+        }
 
-        node.__bckgDimensions = bckgDimensions; // to re-use in nodePointerAreaPaint
+        node.__bckgDimensions = [nodeWidth, nodeHeight]; // to re-use in nodePointerAreaPaint
     })
     .nodePointerAreaPaint((node, color, ctx) => {
         ctx.fillStyle = color;

--- a/graph.js
+++ b/graph.js
@@ -26,8 +26,10 @@ const Graph = ForceGraph()
         return popup.innerHTML;
     })
     .nodeCanvasObject((node, ctx, globalScale) => {
-        // const labels = [node.id, node.user, node.uid];
-        const labels = [node.id];
+        const labels = [];
+        if (showCids) labels.push(node.id);
+        if (showUsers) labels.push(node.user);
+        if (showUids) labels.push(node.uid);
         const fontSize = 12/globalScale;
         ctx.font = `${fontSize}px Sans-Serif`;
         const textWidth = Math.max(...labels.map(label => ctx.measureText(label).width));

--- a/graph.js
+++ b/graph.js
@@ -44,10 +44,10 @@ const myGraph = ForceGraph()
         if (t == 'c') window.open("https://www.openstreetmap.org/changeset/" + id);
     });
 
-if (showCids || showUsers || showUids) {
+if (showIds || showUsers || showUids) {
     myGraph.nodeCanvasObject((node, ctx, globalScale) => {
         const labels = [];
-        if (showCids) labels.push(node.id);
+        if (showIds) labels.push(node.id);
         if (showUsers) labels.push(node.user);
         if (showUids) labels.push(node.uid);
         const fontSize = 12/globalScale;

--- a/graph.js
+++ b/graph.js
@@ -1,0 +1,5 @@
+const Graph = ForceGraph()
+(document.getElementById('graph'))
+    .graphData(gData)
+    .linkWidth(({weight}) => 32*Math.log(weight)/Math.log(10000))
+    .linkDirectionalArrowLength(6);

--- a/graph.js
+++ b/graph.js
@@ -23,6 +23,14 @@ const myGraph = ForceGraph()
             `by `, user, document.createElement('br'),
             `with uid #${node.uid}`
         );
+        if (node.comment) {
+            const comment = document.createElement('small');
+            comment.append(node.comment);
+            popup.append(
+                document.createElement('br'),
+                comment
+            );
+        }
         return popup.innerHTML;
     }).onNodeClick(node => {
         window.open("https://www.openstreetmap.org/changeset/" + node.id);


### PR DESCRIPTION
- add/remove changesets to a graph rendered by [force-graph](https://github.com/vasturiano/force-graph)
- edges correspond to elements with previous/next versions edited in another chageset
- edge weights correspond to number of elements with consecutive versions edited in both changesets
- changeset without outgoing edges can be reverted without generating edit conflicts

![image](https://github.com/woodpeck/osm-revert-scripts/assets/4158490/105d823c-78aa-44fc-a93f-e28b35c00e47)
